### PR TITLE
Add check that BOOST_HAS_LONG_LONG is supported on Darwin

### DIFF
--- a/include/boost/config/compiler/gcc.hpp
+++ b/include/boost/config/compiler/gcc.hpp
@@ -74,8 +74,12 @@
 
 //
 // gcc has "long long"
+// Except on Darwin with standard compliance enabled (-pedantic)
+// Apple gcc helpfully defines this macro we can query
 //
-#define BOOST_HAS_LONG_LONG
+#if !defined(__DARWIN_NO_LONG_LONG)
+# define BOOST_HAS_LONG_LONG
+#endif
 
 //
 // gcc implements the named return value optimization since version 3.1


### PR DESCRIPTION
before enabling the macro.  Apple helpfully supplies this
macro (__DARWIN_NO_LONG_LONG) if long long type is supported.
This to handle case where compiling with -pedantic causes
compiler errors because it enforces ISO compliance
(c++98 in this case).

This will fix several tests in develop and master and will clean conversion tests completely on Mac.
