### PR TITLE
Fixing failing test case boost_no_cxx11_hdr_regex.

### DIFF
--- a/test/boost_no_cxx11_hdr_regex.ipp
+++ b/test/boost_no_cxx11_hdr_regex.ipp
@@ -1,5 +1,5 @@
 //  (C) Copyright Beman Dawes 2009
-
+//  Copyright (c) Microsoft Corporation
 //  Use, modification and distribution are subject to the
 //  Boost Software License, Version 1.0. (See accompanying file
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -20,7 +20,7 @@ int test()
   using std::wregex;
 
   regex e("\\d+");
-  wregex we(L"\\s+");
+  wregex we(L"\\d+");
   std::string s("123456");
   std::wstring ws(L"123456");
   return regex_match(s, e) && regex_match(ws, we) ? 0 : 1;


### PR DESCRIPTION
Just the test case fix from previous pull request #13.
