### PR TITLE
Add support for VC++ 14

### DIFF
--- a/include/boost/config/compiler/visualc.hpp
+++ b/include/boost/config/compiler/visualc.hpp
@@ -168,9 +168,11 @@
 #  define BOOST_NO_CXX11_DECLTYPE_N3276
 #endif
 
-// C++11 features supported by VC++ 14 CTP1.
+// C++11 features supported by VC++ 14 CTP1
+// Because the CTP is unsupported, unrelease, and only alpha quality,
+// it is only supported if BOOST_MSVC_ENABLE_2014_JUN_CTP is defined.
 //
-#if _MSC_FULL_VER < 190021730
+#if (_MSC_FULL_VER < 190021730) || !defined(BOOST_MSVC_ENABLE_2014_JUN_CTP)
 #  define BOOST_NO_CXX11_NOEXCEPT
 #  define BOOST_NO_CXX11_REF_QUALIFIERS
 #  define BOOST_NO_CXX11_USER_DEFINED_LITERALS


### PR DESCRIPTION
All the config tests pass, with the exception of the user-defined literal test, which passes only if "static constexpr" is substituted with "static BOOST_CONSTEXPR_OR_CONST" and "constexpr" is substituted with "BOOST_CONSTEXPR".

See
http://blogs.msdn.com/b/vcblog/archive/2014/06/03/visual-studio-14-ctp.aspx
and
http://blogs.msdn.com/b/somasegar/archive/2014/05/28/first-preview-of-visual-studio-quot-14-quot-available-now.aspx
