### PR TITLE
Various g++/clang config_test fixes

### DIFF
--- a/test/boost_no_cxx11_hdr_typeindex.ipp
+++ b/test/boost_no_cxx11_hdr_typeindex.ipp
@@ -16,10 +16,18 @@ namespace boost_no_cxx11_hdr_typeindex {
 
 int test()
 {
+#if defined( BOOST_NO_TYPEID )
+  std::type_index * p1;
+  std::hash<std::type_index> h;
+  (void)p1;
+  (void)h;
+  return 0;
+#else
   std::type_index t1 = typeid(int);
   std::type_index t2 = typeid(double);
   std::hash<std::type_index> h;
   return (t1 != t2) && (h(t1) != h(t2)) ? 0 : 1;
+#endif
 }
 
 }

--- a/test/boost_no_lambdas.ipp
+++ b/test/boost_no_lambdas.ipp
@@ -18,7 +18,7 @@ namespace boost_no_cxx11_lambdas {
 
 int test()
 {
-  (void)[](){};
+  [](){}();
   return 0;
 }
 

--- a/test/boost_no_ret_det.ipp
+++ b/test/boost_no_ret_det.ipp
@@ -12,12 +12,19 @@
 //                 compilers insist on it, while other issue a
 //                 bunch of warnings if it is in fact present.
 
+#if defined( BOOST_NO_EXCEPTIONS ) && !defined( _MSC_VER )
+# include <stdlib.h>
+#endif
 
 namespace boost_no_unreachable_return_detection{
 
 int checker()
 {
+#if defined( BOOST_NO_EXCEPTIONS ) && !defined( _MSC_VER )
+   abort();
+#else
    throw 0;
+#endif
    // no return statement: we don't ever get here...
 }
 

--- a/test/boost_no_rtti.ipp
+++ b/test/boost_no_rtti.ipp
@@ -43,6 +43,12 @@ int check_f(const A& a)
 
 int test()
 {
+#if defined( BOOST_NO_EXCEPTIONS )
+   {
+      B b;
+      return check_f(b);
+   }
+#else
    try{
       B b;
       return check_f(b);
@@ -51,6 +57,7 @@ int test()
    {
       return 1;
    }
+#endif
 }
 
 }


### PR DESCRIPTION
This updates the test files to not use `throw/try/catch` when exceptions are off, to not use `typeid` when RTTI is off, and to not cast a lambda to `void` as this triggers a g++ bug.
