### PR TITLE
Add additional linkflags for no-rtti, no-except runs of config_test.

### DIFF
--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -54,6 +54,9 @@ test-suite config
           : #input-files
           : #requirements
           <rtti>off
+          <target-os>linux:<linkflags>-lpthread
+          <target-os>linux:<linkflags>-lrt
+          <toolset>gcc:<linkflags>$(OTHERFLAGS)
           : config_test_no_rtti
     ]
     [ run config_test.cpp
@@ -61,6 +64,9 @@ test-suite config
           : #input-files
           : #requirements
           <exception-handling>off
+          <target-os>linux:<linkflags>-lpthread
+          <target-os>linux:<linkflags>-lrt
+          <toolset>gcc:<linkflags>$(OTHERFLAGS)
           : config_test_no_except
     ]
      [ run config_info.cpp : : : <test-info>always_show_run_output <threading>single <toolset>msvc:<runtime-link>static <toolset>msvc:<link>static ]


### PR DESCRIPTION
This copies the additional `<linkflags>` to the no-RTTI and no exceptions runs of `config_test`, as the test results show failures indicating a missing `-lpthread` or `-lrt`.
