### PR TITLE
nvcc with clang needs to emulate gcc

### DIFF
--- a/include/boost/config/select_compiler_config.hpp
+++ b/include/boost/config/select_compiler_config.hpp
@@ -39,7 +39,8 @@
 //  Intel
 #   define BOOST_COMPILER_CONFIG "boost/config/compiler/intel.hpp"
 
-#elif defined __clang__
+#elif defined __clang__ && !defined(__CUDACC__)
+//  when using clang and cuda at same time, you want to appear as gcc
 //  Clang C++ emulates GCC, so it has to appear early.
 #   define BOOST_COMPILER_CONFIG "boost/config/compiler/clang.hpp"
 


### PR DESCRIPTION
The problem is that the nvcc with the clang backend is expecting clang to be emulating gcc.

See my initial comment on: https://svn.boost.org/trac/boost/ticket/8647
