### PR TITLE
Define BOOST_NO_CXX11_NON_PUBLIC_DEFAULTED_FUNCTIONS for Intel

### DIFF
--- a/include/boost/config/compiler/intel.hpp
+++ b/include/boost/config/compiler/intel.hpp
@@ -321,7 +321,7 @@ template<> struct assert_intrinsic_wchar_t<unsigned short> {};
 // Intel 13.10 fails to access defaulted functions of a base class declared in private or protected sections,
 // producing the following errors:
 // error #453: protected function "..." (declared at ...") is not accessible through a "..." pointer or object
-#if !defined(BOOST_NO_CXX11_DEFAULTED_FUNCTIONS) && (BOOST_INTEL_CXX_VERSION <= 1310)
+#if (BOOST_INTEL_CXX_VERSION <= 1310)
 #  define BOOST_NO_CXX11_NON_PUBLIC_DEFAULTED_FUNCTIONS
 #endif
 


### PR DESCRIPTION
Problem can be seen in regression test reports: [variant](http://www.boost.org/development/tests/develop/developer/output/Sandia-intel-13-1-c++0x-boost-bin-v2-libs-variant-test-recursive_variant_test-test-intel-linux-debug.html), [lexical_cast](http://www.boost.org/development/tests/develop/developer/output/Sandia-intel-13-1-c++0x-boost-bin-v2-libs-lexical_cast-test-lexical_cast_containers_test-test-intel-linux-debug-link-static.html), [logic](http://www.boost.org/development/tests/develop/developer/output/Sandia-intel-13-1-c++0x-boost-bin-v2-libs-logic-test-tribool_io_test-test-intel-linux-debug.html), [xpressive](http://www.boost.org/development/tests/develop/developer/output/Sandia-intel-13-1-c++0x-boost-bin-v2-libs-xpressive-test-regress_u-test-intel-linux-debug-debug-symbols-off-link-static.html) and others...
