### PR TITLE
Only define BOOST_COMPILER if not already done

### DIFF
--- a/include/boost/config/compiler/intel.hpp
+++ b/include/boost/config/compiler/intel.hpp
@@ -34,11 +34,14 @@
 #  define BOOST_INTEL_STDCXX0X
 #endif
 
-#ifdef BOOST_INTEL_STDCXX0X
-#define BOOST_COMPILER "Intel C++ C++0x mode version " BOOST_STRINGIZE(BOOST_INTEL_CXX_VERSION)
-#else
-#define BOOST_COMPILER "Intel C++ version " BOOST_STRINGIZE(BOOST_INTEL_CXX_VERSION)
+#if !defined(BOOST_COMPILER)
+#  if defined(BOOST_INTEL_STDCXX0X)
+#    define BOOST_COMPILER "Intel C++ C++0x mode version " BOOST_STRINGIZE(BOOST_INTEL_CXX_VERSION)
+#  else
+#    define BOOST_COMPILER "Intel C++ version " BOOST_STRINGIZE(BOOST_INTEL_CXX_VERSION)
+#  endif
 #endif
+
 #define BOOST_INTEL BOOST_INTEL_CXX_VERSION
 
 #if defined(_WIN32) || defined(_WIN64)


### PR DESCRIPTION
 (as it is already the case for g++ and ms).

Usefull when called through cuda's nvcc.
fixes #10420
