### PR TITLE
Make std lib detection a bit more lightweight

### DIFF
--- a/include/boost/config/select_stdlib_config.hpp
+++ b/include/boost/config/select_stdlib_config.hpp
@@ -2,6 +2,7 @@
 
 //  (C) Copyright John Maddock 2001 - 2003. 
 //  (C) Copyright Jens Maurer 2001 - 2002. 
+//  (C) Copyright Ion Gaztanaga 2014. 
 //  Use, modification and distribution are subject to the 
 //  Boost Software License, Version 1.0. (See accompanying file 
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -11,7 +12,7 @@
 
 // locate which std lib we are using and define BOOST_STDLIB_CONFIG as needed:
 
-// First include <cstddef> to determine if some version of STLport is in use as the std lib
+// First include <cstddef> to determine if some version of std lib is in use
 // (do not rely on this header being included since users can short-circuit this header 
 //  if they know whose std lib they are using.)
 #ifdef __cplusplus
@@ -20,80 +21,22 @@
 #  include <stddef.h>
 #endif
 
-#if defined(__SGI_STL_PORT) || defined(_STLPORT_VERSION)
-// STLPort library; this _must_ come first, otherwise since
-// STLport typically sits on top of some other library, we
-// can end up detecting that first rather than STLport:
-#  define BOOST_STDLIB_CONFIG "boost/config/stdlib/stlport.hpp"
+#include <boost/config/select_stdlib_config_detect.hpp>
 
-#else
-
-// If our std lib was not some version of STLport, then include <utility> as it is about 
-// the smallest of the std lib headers that includes real C++ stuff.  (Some std libs do not
+// If our std lib was not detected with cstddef, then include <utility> as it is about 
+// the smallest of the std lib headers that includes real C++ stuff. (Some std libs do not
 // include their C++-related macros in <cstddef> so this additional include makes sure
 // we get those definitions)
 // (again do not rely on this header being included since users can short-circuit this 
 //  header if they know whose std lib they are using.)
-#include <boost/config/no_tr1/utility.hpp>
+#if !defined(BOOST_STDLIB_CONFIG)
+#  include <boost/config/no_tr1/utility.hpp>
+#  include <boost/config/select_stdlib_config_detect.hpp>
+#endif 
 
-#if defined(__LIBCOMO__)
-// Comeau STL:
-#define BOOST_STDLIB_CONFIG "boost/config/stdlib/libcomo.hpp"
-
-#elif defined(__STD_RWCOMPILER_H__) || defined(_RWSTD_VER)
-// Rogue Wave library:
-#  define BOOST_STDLIB_CONFIG "boost/config/stdlib/roguewave.hpp"
-
-#elif defined(_LIBCPP_VERSION)
-// libc++
-#  define BOOST_STDLIB_CONFIG "boost/config/stdlib/libcpp.hpp"
-
-#elif defined(__GLIBCPP__) || defined(__GLIBCXX__)
-// GNU libstdc++ 3
-#  define BOOST_STDLIB_CONFIG "boost/config/stdlib/libstdcpp3.hpp"
-
-#elif defined(__STL_CONFIG_H)
-// generic SGI STL
-#  define BOOST_STDLIB_CONFIG "boost/config/stdlib/sgi.hpp"
-
-#elif defined(__MSL_CPP__)
-// MSL standard lib:
-#  define BOOST_STDLIB_CONFIG "boost/config/stdlib/msl.hpp"
-
-#elif defined(__IBMCPP__)
-// take the default VACPP std lib
-#  define BOOST_STDLIB_CONFIG "boost/config/stdlib/vacpp.hpp"
-
-#elif defined(MSIPL_COMPILE_H)
-// Modena C++ standard library
-#  define BOOST_STDLIB_CONFIG "boost/config/stdlib/modena.hpp"
-
-#elif (defined(_YVALS) && !defined(__IBMCPP__)) || defined(_CPPLIB_VER)
-// Dinkumware Library (this has to appear after any possible replacement libraries):
-#  define BOOST_STDLIB_CONFIG "boost/config/stdlib/dinkumware.hpp"
-
-#elif defined (BOOST_ASSERT_CONFIG)
+#if !defined(BOOST_STDLIB_CONFIG) && defined(BOOST_ASSERT_CONFIG)
 // this must come last - generate an error if we don't
 // recognise the library:
 #  error "Unknown standard library - please configure and report the results to boost.org"
 
 #endif
-
-#endif
-
-#if 0
-//
-// This section allows dependency scanners to find all the files we *might* include:
-//
-#  include "boost/config/stdlib/stlport.hpp"
-#  include "boost/config/stdlib/libcomo.hpp"
-#  include "boost/config/stdlib/roguewave.hpp"
-#  include "boost/config/stdlib/libcpp.hpp"
-#  include "boost/config/stdlib/libstdcpp3.hpp"
-#  include "boost/config/stdlib/sgi.hpp"
-#  include "boost/config/stdlib/msl.hpp"
-#  include "boost/config/stdlib/vacpp.hpp"
-#  include "boost/config/stdlib/modena.hpp"
-#  include "boost/config/stdlib/dinkumware.hpp"
-#endif
-

--- a/include/boost/config/select_stdlib_config_detect.hpp
+++ b/include/boost/config/select_stdlib_config_detect.hpp
@@ -1,0 +1,75 @@
+//  Boost compiler configuration selection header file
+
+//  (C) Copyright John Maddock 2001 - 2003. 
+//  (C) Copyright Jens Maurer 2001 - 2002. 
+//  (C) Copyright Ion Gaztanaga 2014. 
+//  Use, modification and distribution are subject to the 
+//  Boost Software License, Version 1.0. (See accompanying file 
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+
+//  See http://www.boost.org for most recent version.
+
+// locate which std lib we are using and define BOOST_STDLIB_CONFIG as needed.
+// if std lib can't be detected, BOOST_STDLIB_CONFIG won't be defined.
+#if defined(__SGI_STL_PORT) || defined(_STLPORT_VERSION)
+// STLPort library; this _must_ come first, otherwise since
+// STLport typically sits on top of some other library, we
+// can end up detecting that first rather than STLport:
+#  define BOOST_STDLIB_CONFIG "boost/config/stdlib/stlport.hpp"
+
+#elif defined(__LIBCOMO__)
+// Comeau STL:
+#define BOOST_STDLIB_CONFIG "boost/config/stdlib/libcomo.hpp"
+
+#elif defined(__STD_RWCOMPILER_H__) || defined(_RWSTD_VER)
+// Rogue Wave library:
+#  define BOOST_STDLIB_CONFIG "boost/config/stdlib/roguewave.hpp"
+
+#elif defined(_LIBCPP_VERSION)
+// libc++
+#  define BOOST_STDLIB_CONFIG "boost/config/stdlib/libcpp.hpp"
+
+#elif defined(__GLIBCPP__) || defined(__GLIBCXX__)
+// GNU libstdc++ 3
+#  define BOOST_STDLIB_CONFIG "boost/config/stdlib/libstdcpp3.hpp"
+
+#elif defined(__STL_CONFIG_H)
+// generic SGI STL
+#  define BOOST_STDLIB_CONFIG "boost/config/stdlib/sgi.hpp"
+
+#elif defined(__MSL_CPP__)
+// MSL standard lib:
+#  define BOOST_STDLIB_CONFIG "boost/config/stdlib/msl.hpp"
+
+#elif defined(__IBMCPP__)
+// take the default VACPP std lib
+#  define BOOST_STDLIB_CONFIG "boost/config/stdlib/vacpp.hpp"
+
+#elif defined(MSIPL_COMPILE_H)
+// Modena C++ standard library
+#  define BOOST_STDLIB_CONFIG "boost/config/stdlib/modena.hpp"
+
+#elif (defined(_YVALS) && !defined(__IBMCPP__)) || defined(_CPPLIB_VER)
+// Dinkumware Library (this has to appear after any possible replacement libraries):
+#  define BOOST_STDLIB_CONFIG "boost/config/stdlib/dinkumware.hpp"
+
+#else
+// BOOST_STDLIB_CONFIG not defined
+#endif
+
+#if 0
+//
+// This section allows dependency scanners to find all the files we *might* include:
+//
+#  include "boost/config/stdlib/stlport.hpp"
+#  include "boost/config/stdlib/libcomo.hpp"
+#  include "boost/config/stdlib/roguewave.hpp"
+#  include "boost/config/stdlib/libcpp.hpp"
+#  include "boost/config/stdlib/libstdcpp3.hpp"
+#  include "boost/config/stdlib/sgi.hpp"
+#  include "boost/config/stdlib/msl.hpp"
+#  include "boost/config/stdlib/vacpp.hpp"
+#  include "boost/config/stdlib/modena.hpp"
+#  include "boost/config/stdlib/dinkumware.hpp"
+#endif


### PR DESCRIPTION
...on environments where cstddef is enough to detect BOOST_STDLIB_CONFIG. Backup to `<utility>` (which has become heavier in C++11, as it needs traits for move_if_noexcept..) if std lib has not been detected.

The patch splits the detection in an auxiliary header and includes it twice in case cstddef is not enough.
