### PR TITLE
Fix error on __has_include with older clang (< 3.1)

### DIFF
--- a/include/boost/config/stdlib/libstdcpp3.hpp
+++ b/include/boost/config/stdlib/libstdcpp3.hpp
@@ -127,15 +127,15 @@
 #  define BOOST_LIBSTDCXX_VERSION 40900
 #elif __has_include(<ext/cmath>)
 #  define BOOST_LIBSTDCXX_VERSION 40800
-#elif __has_include(chrono)
+#elif __has_include(<chrono>)
 #  define BOOST_LIBSTDCXX_VERSION 40700
-#elif __has_include(typeindex)
+#elif __has_include(<typeindex>)
 #  define BOOST_LIBSTDCXX_VERSION 40600
-#elif __has_include(future)
+#elif __has_include(<future>)
 #  define BOOST_LIBSTDCXX_VERSION 40500
-#elif  __has_include(ratio)
+#elif  __has_include(<ratio>)
 #  define BOOST_LIBSTDCXX_VERSION 40400
-#elif __has_include(array)
+#elif __has_include(<array>)
 #  define BOOST_LIBSTDCXX_VERSION 40300
 #endif
 //


### PR DESCRIPTION
Older clang (< 3.1) rejects __has_include(header), therefore use __has_include(&lt;header&gt;) instead.

see [Test output: teeks99-03f-Ubuntu12.04-64 - config - abi_test / clang-linux-3.0](http://www.boost.org/development/tests/develop/developer/output/teeks99-03f-Ubuntu12-04-64-boost-bin-v2-libs-config-test-abi_test-test-clang-linux-3-0-debug.html)
