### PR TITLE
Define BOOST_NO_CXX14_CONSTEXPR unless clang > 3.4.

### DIFF
--- a/include/boost/config/compiler/clang.hpp
+++ b/include/boost/config/compiler/clang.hpp
@@ -225,7 +225,16 @@
 #  define BOOST_NO_CXX14_GENERIC_LAMBDAS
 #endif
 
-#if !(__has_feature(cxx_relaxed_constexpr) || __has_extension(cxx_relaxed_constexpr))
+// clang < 3.5 has a defect with dependent type, like following.
+//
+//  template <class T>
+//  constexpr typename enable_if<pred<T> >::type foo(T &)
+//  { } // error: no return statement in constexpr function
+//
+// This issue also affects C++11 mode, but C++11 constexpr requires return stmt.
+// Therefore we don't care such case.
+#if (__clang_major__ == 3 && __clang_minor__ < 5) \
+  || !(__has_feature(cxx_relaxed_constexpr) || __has_extension(cxx_relaxed_constexpr))
 #  define BOOST_NO_CXX14_CONSTEXPR
 #endif
 

--- a/test/boost_no_cxx14_constexpr.ipp
+++ b/test/boost_no_cxx14_constexpr.ipp
@@ -14,7 +14,15 @@
 namespace boost_no_cxx14_constexpr
 {
 
-constexpr void decrement(int &value)
+namespace detail
+{
+    template <class> struct void_ { typedef void type; };
+}
+
+// Test relaxed constexpr with dependent type; for more details, see comment of
+// BOOST_CXX14_CONSTEXPR definition in boost/config/compiler/clang.hpp .
+template <class T>
+constexpr typename detail::void_<T>::type decrement(T &value)
 {
     --value;
 }


### PR DESCRIPTION
clang (< 3.5) has a defet with constexpr and dependent type.
- 3.4 http://melpon.org/wandbox/permlink/xe6bdDS3mPPLhbA3 (fail)
- 3.5 http://melpon.org/wandbox/permlink/weorcI0Mb9u8g98r

This issue will afect fusion::swap constexpr supporting.
- [Test output: marshall-mac - fusion - swap / clang-darwin-11](http://www.boost.org/development/tests/develop/developer/output/marshall-mac-boost-bin-v2-libs-fusion-test-swap-test-clang-darwin-11-debug.html)
  - Above test run under c++11 mode, though c++14 mode is also affected.
