### PR TITLE
Lift architecture detection

### DIFF
--- a/checks/architecture/32.cpp
+++ b/checks/architecture/32.cpp
@@ -1,0 +1,9 @@
+// 32.cpp
+//
+// Copyright (c) 2012 Steven Watanabe
+//
+// Distributed under the Boost Software License Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+int test[sizeof(void*) == 4? 1 : -1];

--- a/checks/architecture/64.cpp
+++ b/checks/architecture/64.cpp
@@ -1,0 +1,9 @@
+// 64.cpp
+//
+// Copyright (c) 2012 Steven Watanabe
+//
+// Distributed under the Boost Software License Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+int test[sizeof(void*) == 8? 1 : -1];

--- a/checks/architecture/Jamroot.jam
+++ b/checks/architecture/Jamroot.jam
@@ -1,0 +1,23 @@
+# Jamfile.jam
+#
+# Copyright 2012 Steven Watanabe
+#
+# Distributed under the Boost Software License Version 1.0. (See
+# accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+project /boost/architecture 
+        : requirements 
+          -<conditional>@boostcpp.deduce-address-model
+          -<conditional>@boostcpp.deduce-architecture 
+        ; 
+
+obj 32 : 32.cpp ;
+obj 64 : 64.cpp ;
+
+obj arm      : arm.cpp ;
+obj combined : combined.cpp ;
+obj mips1    : mips1.cpp ;
+obj power    : power.cpp ;
+obj sparc    : sparc.cpp ;
+obj x86      : x86.cpp ;

--- a/checks/architecture/arm.cpp
+++ b/checks/architecture/arm.cpp
@@ -1,0 +1,13 @@
+// arm.cpp
+//
+// Copyright (c) 2012 Steven Watanabe
+//
+// Distributed under the Boost Software License Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(__arm__) && !defined(__thumb__) && \
+    !defined(__TARGET_ARCH_ARM) && !defined(__TARGET_ARCH_THUMB) && \
+    !defined(_ARM) && !defined(_M_ARM)
+#error "Not ARM"
+#endif

--- a/checks/architecture/combined.cpp
+++ b/checks/architecture/combined.cpp
@@ -1,0 +1,21 @@
+// combined.cpp
+//
+// Copyright (c) 2012 Steven Watanabe
+//               2014 Oliver Kowalke
+//
+// Distributed under the Boost Software License Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(i386) && !defined(__i386__) && !defined(__i386) \
+    && !defined(__i486__) && !defined(__i586__) && !defined(__i686__) \
+    && !defined(_M_IX86) && !defined(__X86__) && !defined(_X86_) \
+    && !defined(__THW_INTEL__) && !defined(__I86__) && !defined(__INTEL__) \
+    && !defined(__amd64__) && !defined(__x86_64__) && !defined(__amd64) \
+    && !defined(__x86_64) && !defined(_M_X64) \
+    && !defined(__powerpc) && !defined(__powerpc__) && !defined(__ppc) \
+    && !defined(__ppc__) && !defined(_M_PPC) && !defined(_ARCH_PPC) \
+    && !defined(__POWERPC__) && !defined(__PPCGECKO__) \
+    && !defined(__PPCBROADWAY) && !defined(_XENON)
+#error "Not combined"
+#endif

--- a/checks/architecture/mips1.cpp
+++ b/checks/architecture/mips1.cpp
@@ -1,0 +1,11 @@
+// mips1.cpp
+//
+// Copyright (c) 2012 Steven Watanabe
+//
+// Distributed under the Boost Software License Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#if !((defined(__mips) && __mips == 1) || defined(_MIPS_ISA_MIPS1) || defined(_R3000))
+#error "Not MIPS1"
+#endif

--- a/checks/architecture/power.cpp
+++ b/checks/architecture/power.cpp
@@ -1,0 +1,14 @@
+// power.cpp
+//
+// Copyright (c) 2012 Steven Watanabe
+//
+// Distributed under the Boost Software License Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(__powerpc) && !defined(__powerpc__) && !defined(__ppc) \
+    && !defined(__ppc__) && !defined(_M_PPC) && !defined(_ARCH_PPC) \
+    && !defined(__POWERPC__) && !defined(__PPCGECKO__) \
+    && !defined(__PPCBROADWAY) && !defined(_XENON)
+#error "Not PPC"
+#endif

--- a/checks/architecture/sparc.cpp
+++ b/checks/architecture/sparc.cpp
@@ -1,0 +1,11 @@
+// power.cpp
+//
+// Copyright (c) 2012 Steven Watanabe
+//
+// Distributed under the Boost Software License Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(__sparc__) && !defined(__sparc)
+#error "Not SPARC"
+#endif

--- a/checks/architecture/x86.cpp
+++ b/checks/architecture/x86.cpp
@@ -1,0 +1,16 @@
+// x86.cpp
+//
+// Copyright (c) 2012 Steven Watanabe
+//
+// Distributed under the Boost Software License Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(i386) && !defined(__i386__) && !defined(__i386) \
+    && !defined(__i486__) && !defined(__i586__) && !defined(__i686__) \
+    && !defined(_M_IX86) && !defined(__X86__) && !defined(_X86_) \
+    && !defined(__THW_INTEL__) && !defined(__I86__) && !defined(__INTEL__) \
+    && !defined(__amd64__) && !defined(__x86_64__) && !defined(__amd64) \
+    && !defined(__x86_64) && !defined(_M_X64)
+#error "Not x86"
+#endif


### PR DESCRIPTION
Part of a patch set from @vprus for fixing https://svn.boost.org/trac/boost/ticket/10858
This patch add the detection logic removed from Boost.Context here.