### PR TITLE
add test maco for feature std::integer_sequence

### DIFF
--- a/include/boost/config/compiler/clang.hpp
+++ b/include/boost/config/compiler/clang.hpp
@@ -8,6 +8,9 @@
 
 // Clang compiler setup.
 
+// __cpp_lib_integer_sequence is defined in header <utility>
+#include <utility>
+
 #define BOOST_HAS_PRAGMA_ONCE
 
 // Detecting `-fms-extension` compiler flag assuming that _MSC_VER defined when that flag is used.
@@ -250,6 +253,11 @@
 #if !__has_feature(__cxx_variable_templates__)
 #  define BOOST_NO_CXX14_VARIABLE_TEMPLATES
 #endif
+
+#if !defined(__cpp_lib_integer_sequence) || (__cpp_lib_integer_sequence < 201304)
+#  define BOOST_NO_CXX14_INTEGER_SEQUENCE
+#endif
+
 
 #if __cplusplus < 201400
 // All versions with __cplusplus above this value seem to support this:

--- a/include/boost/config/compiler/gcc.hpp
+++ b/include/boost/config/compiler/gcc.hpp
@@ -13,6 +13,9 @@
 
 //  GNU C++ compiler setup.
 
+// __cpp_lib_integer_sequence is defined in header <utility>
+#include <utility>
+
 //
 // Define BOOST_GCC so we know this is "real" GCC and not some pretender:
 //
@@ -258,6 +261,9 @@
 #endif
 #if !defined(__cpp_variable_templates) || (__cpp_variable_templates < 201304)
 #  define BOOST_NO_CXX14_VARIABLE_TEMPLATES
+#endif
+#if !defined(__cpp_lib_integer_sequence) || (__cpp_lib_integer_sequence < 201304)
+#  define BOOST_NO_CXX14_INTEGER_SEQUENCE
 #endif
 
 //


### PR DESCRIPTION
- std::integer_sequence is a C++14 feature
- SD-6 macro __cpp_lib_integer_sequence is used to test this feature
- __cpp_lib_integer_sequence is defined in header <utility>
- if std::integer_sequence is not available, BOOST_NO_CXX14_INTEGER_SEQUENCE is defined