### PR TITLE
Add more constexpr tests

### DIFF
--- a/test/boost_no_constexpr.ipp
+++ b/test/boost_no_constexpr.ipp
@@ -36,6 +36,32 @@ constexpr const A a = 42;
 
 X<a> xx; // OK: unique conversion to int
 
+// virtual function
+struct B
+{
+   virtual void vf() {}
+};
+struct C : B
+{
+   constexpr C() {}
+};
+
+// aggregate initialization
+struct D
+{
+   int val[2];
+   constexpr D() : val() {}
+};
+
+// virtual base
+struct E
+{
+};
+struct F : virtual E
+{
+};
+constexpr F& f(F& out) { return out; }
+
 int test()
 {
   int i = square(5);


### PR DESCRIPTION
MSVC 14 RC currently passes the constexpr tests, but fails to compile Boost if BOOST_NO_CXX11_CONSTEXPR is not defined. Added three tests that clang can compile in C++11 mode, but MSVC cannot.