### PR TITLE
Macro configuration system where you can use Boost library or equivalent C++ standard library with same code

### DIFF
--- a/doc/choosing.qbk
+++ b/doc/choosing.qbk
@@ -66,6 +66,15 @@ The following table lists the libraries and the appropriate information for each
 [[unordered_set][<boost/config/cpp/unordered_set.hpp>][BOOST_CPP_UNORDERED_SET_HDR][BOOST_CPP_UNORDERED_SET_NS][BOOST_CPP_HAS_UNORDERED_SET]]
 ]
 
+Not mentioned or listed above is a macro of the form BOOST_CPP_XXX_MACRO, which is only 
+defined for a library XXX which has equivalent macro names between the C++ standard library 
+version and the Boost library version. This macro is used in the form of 
+BOOST_CPP_XXX_MACRO(MACRO_NAME) to produce the correct macro name for the equivalent macro no 
+matter which implementation is being used. Currently, among the libraries listed above, the only 
+library which uses this form is the 'atomic' library. It's name therefore is BOOST_CPP_ATOMIC_MACRO 
+and it can be used in the form of BOOST_CPP_ATOMIC_MACRO(AN_ATOMIC_MACRO) to produce the correct 
+equivalent macro name for the 'atomic' library.
+
 [heading Using the macros ]
 
 The general form of using these macros in a translation unit will now be given, 

--- a/doc/choosing.qbk
+++ b/doc/choosing.qbk
@@ -1,0 +1,161 @@
+
+[section Macros that choose standard or Boost libraries]
+
+A number of Boost libraries are also represented in the C++ standard with 
+corresponding C++ standard libraries. While the Boost and corresponding 
+C++ standard library do not necessarily have exactly the same functionality 
+they are often close enough in their functionality so that either can be used
+for particular programming tasks.
+
+A programmer may want to use the C++ standard version of such a library, 
+if it has been made available by the compiler implementation, rather than the
+Boost version of the library, in order to remove a dependency in code on
+the Boost version of such a library.
+
+Boost.config offers macros which allow the programmer to automatically
+include and use the appropriate version of the library, whether C++ standard
+or Boost. 
+
+These macros are not included automatically when <boost/config.h>
+is included as a header file. Instead the programmer includes the
+appropriate header file for a particular library from within the 
+boost/config/cpp subdirectory, and then makes use of macros in that header
+file to automatically use either the C++ standard version of that
+library, if it is available for the particulat compiler implementation,
+or the Boost version of that library, if the C++ standard version is not 
+available for the particular compiler implementation.
+
+For a give library 'XXX' which exists as a Boost version and may exist
+as a C++ standard library version, the user will:
+
+* #include <boost/config/cpp/XXX.hpp>
+* Use BOOST_CPP_XXX_HDR in order to include the header file for that library,
+ie. #include BOOST_CPP_XXX_HDR
+* Use the macro BOOST_CPP_XXX_NS as the namespace for that library when using the 
+functionality of that library, ie. BOOST_CPP_XXX_NS::some_library_functionality
+* If necessary use the macro BOOST_CPP_HAS_XXX to determine whether the C++ standard
+version of the library is available or not. If BOOST_CPP_HAS_XXX is 1 the C++ standard
+version of the library is available for use and if BOOST_CPP_HAS_XXX is 0 only the
+Boost version of the library is available for use, ie. #if BOOST_CPP_HAS_XXX for code
+that depends only on the C++ standard version of the library or #if !BOOST_CPP_HAS_XXX
+for code that depends only on the Boost version of the library
+
+The following table lists the libraries and the appropriate information for each one:
+
+[
+table:cpp_libs Libraries
+[[Library][Header file][Include macro][Namespace macro][Check C++ standard version macro]]
+[[array][<boost/config/cpp/array.hpp>][BOOST_CPP_ARRAY_HDR][BOOST_CPP_ARRAY_NS][BOOST_CPP_HAS_ARRAY]]
+[[atomic][<boost/config/cpp/atomic.hpp>][BOOST_CPP_ATOMIC_HDR][BOOST_CPP_ATOMIC_NS][BOOST_CPP_HAS_ATOMIC]]
+[[bind][<boost/config/cpp/bind.hpp>][BOOST_CPP_BIND_HDR][BOOST_CPP_BIND_NS][BOOST_CPP_HAS_BIND]]
+[[chrono][<boost/config/cpp/chrono.hpp>][BOOST_CPP_CHRONO_HDR][BOOST_CPP_CHRONO_NS][BOOST_CPP_HAS_CHRONO]]
+[[function][<boost/config/cpp/function.hpp>][BOOST_CPP_FUNCTION_HDR][BOOST_CPP_FUNCTION_NS][BOOST_CPP_HAS_FUNCTION]]
+[[hash][<boost/config/cpp/hash.hpp>][BOOST_CPP_HASH_HDR][BOOST_CPP_HASH_NS][BOOST_CPP_HAS_HASH]]
+[[mem_fn][<boost/config/cpp/mem_fn.hpp>][BOOST_CPP_MEM_FN_HDR][BOOST_CPP_MEM_FN_NS][BOOST_CPP_HAS_MEM_FN]]
+[[random][<boost/config/cpp/random.hpp>][BOOST_CPP_RANDOM_HDR][BOOST_CPP_RANDOM_NS][BOOST_CPP_HAS_RANDOM]]
+[[ratio][<boost/config/cpp/ratio.hpp>][BOOST_CPP_RATIO_HDR][BOOST_CPP_RATIO_NS][BOOST_CPP_HAS_RATIO]]
+[[ref][<boost/config/cpp/ref.hpp>][BOOST_CPP_REF_HDR][BOOST_CPP_REF_NS][BOOST_CPP_HAS_REF]]
+[[regex][<boost/config/cpp/regex.hpp>][BOOST_CPP_REGEX_HDR][BOOST_CPP_REGEX_NS][BOOST_CPP_HAS_REGEX]]
+[[shared_ptr][<boost/config/cpp/shared_ptr.hpp>][BOOST_CPP_SHARED_PTR_HDR][BOOST_CPP_SHARED_PTR_NS][BOOST_CPP_HAS_SHARED_PTR]]
+[[thread][<boost/config/cpp/thread.hpp>][BOOST_CPP_THREAD_HDR][BOOST_CPP_THREAD_NS][BOOST_CPP_HAS_THREAD]]
+[[tuple][<boost/config/cpp/tuple.hpp>][BOOST_CPP_TUPLE_HDR][BOOST_CPP_TUPLE_NS][BOOST_CPP_HAS_TUPLE]]
+[[type_index][<boost/config/cpp/type_index.hpp>][BOOST_CPP_TYPE_INDEX_HDR][BOOST_CPP_TYPE_INDEX_NS][BOOST_CPP_HAS_TYPE_INDEX]]
+[[type_traits][<boost/config/cpp/type_traits.hpp>][BOOST_CPP_TYPE_TRAITS_HDR][BOOST_CPP_TYPE_TRAITS_NS][BOOST_CPP_HAS_TYPE_TRAITS]]
+[[unordered_map][<boost/config/cpp/unordered_map.hpp>][BOOST_CPP_UNORDERED_MAP_HDR][BOOST_CPP_UNORDERED_MAP_NS][BOOST_CPP_HAS_UNORDERED_MAP]]
+[[unordered_multimap][<boost/config/cpp/unordered_multimap.hpp>][BOOST_CPP_UNORDERED_MULTIMAP_HDR][BOOST_CPP_UNORDERED_MULTIMAP_NS][BOOST_CPP_HAS_UNORDERED_MULTIMAP]]
+[[unordered_multiset][<boost/config/cpp/unordered_multiset.hpp>][BOOST_CPP_UNORDERED_MULTISET_HDR][BOOST_CPP_UNORDERED_MULTISET_NS][BOOST_CPP_HAS_UNORDERED_MULTISET]]
+[[unordered_set][<boost/config/cpp/unordered_set.hpp>][BOOST_CPP_UNORDERED_SET_HDR][BOOST_CPP_UNORDERED_SET_NS][BOOST_CPP_HAS_UNORDERED_SET]]
+]
+
+[heading Using the macros ]
+
+The general form of using these macros in a translation unit will now be given, 
+choosing the regex library as an example.
+
+  #include <boost/config/cpp/regex.hpp>
+  #include BOOST_CPP_REGEX_HDR
+  
+  void SomeFunction()
+    {
+    BOOST_CPP_REGEX_NS::regex re("A regular expression etc.");
+    bool result(BOOST_CPP_REGEX_NS::regex_match("Some string...",re));
+    // etc.
+    }
+    
+In the example the code will work whether we are using the C++ standard regex library
+or the Boost regex library.
+
+[heading Using the BOOST_CPP_HAS_... macro ]
+
+The BOOST_CPP_HAS_ macro for any given library is a more understandable form of macro than
+Boost.config already has for determining whether the compiler supports certain C++ libraries.
+Most of these macros are taken from whether or not a given BOOST_NO_CXX11_HDR_ is defined.
+You can use a BOOST_CPP_HAS_ macro to discover whether a Boost library is also supported
+by an equivalent C++ standard library. You may decide you need the C++ standard version of
+a particular library, rather than the Boost version, or else you do not want your code to
+compile. As an example let's say that you want to create a compile error if the compiler
+does not support the C++ standard library type_traits library, even though the Boost type_traits
+library could also normally be used.
+
+  #include <boost/config/cpp/type_traits.hpp>
+  #if !BOOST_CPP_HAS_TYPE_TRAITS
+  #error C++ standard type_traits library needed and not present.
+  #endif
+  
+  // Further code
+  
+Another use for the BOOST_CPP_HAS_ macro is to include particular header files
+rather than a main header file, for some given library functionality. This is
+more prevalent with Boost than with the C++ standard library, the latter almost
+always having a single header file which includes library functionality for
+all parts of a library. 
+    
+  #include <boost/config/cpp/type_traits.hpp>
+  #if BOOST_CPP_HAS_TYPE_TRAITS
+  #include BOOST_CPP_TYPE_TRAITS_HDR
+  #else
+  #include <boost/type_traits/add_const.hpp>
+  #endif
+  
+  // Further code using BOOST_CPP_TYPE_TRAITS_NS::add_const
+  
+You can also use the BOOST_CPP_HAS_ macro to provide specific functionality
+depending on whether or not a particular library is using the C++ standard
+or Boost version. Of course you hope to minimize these situations but occasionally
+they happen:
+  
+  #include <boost/config/cpp/thread.hpp>
+  #include BOOST_CPP_THREAD_HDR
+  
+  // Code...
+  
+  #if BOOST_CPP_HAS_THREAD
+  
+  // Functionality available if the C++ standard version of the thread library is being used
+  
+  #else
+  
+  // Functionality available if the Boost version of the thread library is being used
+  
+  #endif
+  
+[heading Library header file dependency ]
+
+When the programmer includes the appropriate header file for a particular 
+library from within the boost/config/cpp subdirectory there is no dependency
+being established on the library itself. Any one of the library header files 
+merely defines macros which the programmer may choose to use or not.
+
+It is only when using a particular include macro, along with a particular namespace
+macro, from any given library that a dependency is established.
+
+Because of this it has been made possible to include all library headers with a
+single include:
+
+  #include <boost/config/cpp.h>
+  
+This includes macros for each library, starting with BOOST_CPP_, but as long 
+as the prefix BOOST_CPP_ does not conflict with macros from any other software 
+library in the translation unit there should be no problems.
+
+[endsect]

--- a/doc/choosing.qbk
+++ b/doc/choosing.qbk
@@ -21,7 +21,7 @@ is included as a header file. Instead the programmer includes the
 appropriate header file for a particular library from within the 
 boost/config/cpp subdirectory, and then makes use of macros in that header
 file to automatically use either the C++ standard version of that
-library, if it is available for the particulat compiler implementation,
+library, if it is available for the particular compiler implementation,
 or the Boost version of that library, if the C++ standard version is not 
 available for the particular compiler implementation.
 
@@ -42,8 +42,7 @@ for code that depends only on the Boost version of the library
 
 The following table lists the libraries and the appropriate information for each one:
 
-[
-table:cpp_libs Libraries
+[table Libraries
 [[Library][Header file][Include macro][Namespace macro][Check C++ standard version macro]]
 [[array][<boost/config/cpp/array.hpp>][BOOST_CPP_ARRAY_HDR][BOOST_CPP_ARRAY_NS][BOOST_CPP_HAS_ARRAY]]
 [[atomic][<boost/config/cpp/atomic.hpp>][BOOST_CPP_ATOMIC_HDR][BOOST_CPP_ATOMIC_NS][BOOST_CPP_HAS_ATOMIC]]
@@ -91,7 +90,9 @@ The BOOST_CPP_HAS_ macro for any given library is a more understandable form of 
 Boost.config already has for determining whether the compiler supports certain C++ libraries.
 Most of these macros are taken from whether or not a given BOOST_NO_CXX11_HDR_ is defined.
 You can use a BOOST_CPP_HAS_ macro to discover whether a Boost library is also supported
-by an equivalent C++ standard library. You may decide you need the C++ standard version of
+by an equivalent C++ standard library. 
+
+You may decide you need the C++ standard version of
 a particular library, rather than the Boost version, or else you do not want your code to
 compile. As an example let's say that you want to create a compile error if the compiler
 does not support the C++ standard library type_traits library, even though the Boost type_traits

--- a/doc/config.qbk
+++ b/doc/config.qbk
@@ -1,5 +1,6 @@
-[article Boost.Config
-    [quickbook 1.4]
+[library Boost.Config
+    [quickbook 1.6]
+    [compatibility-mode 1.4]
     [authors [Beman Dawes, Vesa Karvonen, John Maddock] ]
     [copyright 2001-2007 Beman Dawes, Vesa Karvonen, John Maddock]
     [category broken compiler workarounds]
@@ -55,8 +56,3 @@ Distributed under the Boost Software License, Version 1.0.
 [include guidelines.qbk]
 [include rationale.qbk]
 [include acknowledgements.qbk]
-
-
-
-
-

--- a/doc/html/boost_config/acknowledgements.html
+++ b/doc/html/boost_config/acknowledgements.html
@@ -4,8 +4,8 @@
 <title>Acknowledgements</title>
 <link rel="stylesheet" href="../../../../../doc/src/boostbook.css" type="text/css">
 <meta name="generator" content="DocBook XSL Stylesheets V1.78.1">
-<link rel="home" href="../index.html" title="Boost.Config">
-<link rel="up" href="../index.html" title="Boost.Config">
+<link rel="home" href="../index.html" title="Chapter&#160;1.&#160;Boost.Config">
+<link rel="up" href="../index.html" title="Chapter&#160;1.&#160;Boost.Config">
 <link rel="prev" href="rationale.html" title="Rationale">
 </head>
 <body bgcolor="white" text="black" link="#0000FF" vlink="#840084" alink="#0000FF">

--- a/doc/html/boost_config/boost_macro_reference.html
+++ b/doc/html/boost_config/boost_macro_reference.html
@@ -4,9 +4,9 @@
 <title>Boost Macro Reference</title>
 <link rel="stylesheet" href="../../../../../doc/src/boostbook.css" type="text/css">
 <meta name="generator" content="DocBook XSL Stylesheets V1.78.1">
-<link rel="home" href="../index.html" title="Boost.Config">
-<link rel="up" href="../index.html" title="Boost.Config">
-<link rel="prev" href="../index.html" title="Boost.Config">
+<link rel="home" href="../index.html" title="Chapter&#160;1.&#160;Boost.Config">
+<link rel="up" href="../index.html" title="Chapter&#160;1.&#160;Boost.Config">
+<link rel="prev" href="../index.html" title="Chapter&#160;1.&#160;Boost.Config">
 <link rel="next" href="build_config.html" title="Build Time Configuration">
 </head>
 <body bgcolor="white" text="black" link="#0000FF" vlink="#840084" alink="#0000FF">
@@ -41,6 +41,8 @@
       that describe C++14 features not supported</a></span></dt>
 <dt><span class="section"><a href="boost_macro_reference.html#boost_config.boost_macro_reference.macros_that_allow_use_of_c__14_features_with_c__11_or_earlier_compilers">Macros
       that allow use of C++14 features with C++11 or earlier compilers</a></span></dt>
+<dt><span class="section"><a href="boost_macro_reference.html#boost_config.boost_macro_reference.macros_that_choose_standard_or_boost_libraries">Macros
+      that choose standard or Boost libraries</a></span></dt>
 <dt><span class="section"><a href="boost_macro_reference.html#boost_config.boost_macro_reference.boost_helper_macros">Boost
       Helper Macros</a></span></dt>
 <dt><span class="section"><a href="boost_macro_reference.html#boost_config.boost_macro_reference.boost_informational_macros">Boost
@@ -322,13 +324,13 @@
                 <p>
                   The compiler fails to compile a nested class that has a dependent
                   base class:
-</p>
+                </p>
 <pre xmlns:rev="http://www.cs.rpi.edu/~gregod/boost/tools/doc/revision" class="table-programlisting"><span class="keyword">template</span><span class="special">&lt;</span><span class="keyword">typename</span> <span class="identifier">T</span><span class="special">&gt;</span>
 <span class="keyword">struct</span> <span class="identifier">foo</span> <span class="special">:</span> <span class="special">{</span>
    <span class="keyword">template</span><span class="special">&lt;</span><span class="keyword">typename</span> <span class="identifier">U</span><span class="special">&gt;</span>
    <span class="keyword">struct</span> <span class="identifier">bar</span> <span class="special">:</span> <span class="keyword">public</span> <span class="identifier">U</span> <span class="special">{};</span>
 </pre>
-<p>
+                <p>
                   };
                 </p>
               </td>
@@ -347,12 +349,10 @@
 <td>
                 <p>
                   Template value parameters cannot have a dependent type, for example:
-</p>
+                </p>
 <pre xmlns:rev="http://www.cs.rpi.edu/~gregod/boost/tools/doc/revision" class="table-programlisting"><span class="keyword">template</span><span class="special">&lt;</span><span class="keyword">class</span> <span class="identifier">T</span><span class="special">,</span> <span class="keyword">typename</span> <span class="identifier">T</span><span class="special">::</span><span class="identifier">type</span> <span class="identifier">value</span><span class="special">&gt;</span>
 <span class="keyword">class</span> <span class="identifier">X</span> <span class="special">{</span> <span class="special">...</span> <span class="special">};</span>
 </pre>
-<p>
-                </p>
               </td>
 </tr>
 <tr>
@@ -410,7 +410,7 @@
                 <p>
                   The compiler does not perform function template ordering or its
                   function template ordering is incorrect.
-</p>
+                </p>
 <pre xmlns:rev="http://www.cs.rpi.edu/~gregod/boost/tools/doc/revision" class="table-programlisting"><span class="comment">// #1</span>
 <span class="keyword">template</span><span class="special">&lt;</span><span class="keyword">class</span> <span class="identifier">T</span><span class="special">&gt;</span> <span class="keyword">void</span> <span class="identifier">f</span><span class="special">(</span><span class="identifier">T</span><span class="special">);</span>
 
@@ -421,8 +421,6 @@
 
 <span class="identifier">f</span><span class="special">(&amp;</span><span class="identifier">bar</span><span class="special">);</span> <span class="comment">// should choose #2.</span>
 </pre>
-<p>
-                </p>
               </td>
 </tr>
 <tr>
@@ -1313,12 +1311,10 @@
                 <p>
                   The compiler does not allow a void function to return the result
                   of calling another void function.
-</p>
+                </p>
 <pre xmlns:rev="http://www.cs.rpi.edu/~gregod/boost/tools/doc/revision" class="table-programlisting"><span class="keyword">void</span> <span class="identifier">f</span><span class="special">()</span> <span class="special">{}</span>
 <span class="keyword">void</span> <span class="identifier">g</span><span class="special">()</span> <span class="special">{</span> <span class="keyword">return</span> <span class="identifier">f</span><span class="special">();</span> <span class="special">}</span>
 </pre>
-<p>
-                </p>
               </td>
 </tr>
 </tbody>
@@ -3233,15 +3229,13 @@
                   <code class="computeroutput"><span class="identifier">X</span></code> must always be
                   a compile-time integer constant. The macro can be used to specify
                   alignment of types and data:
-</p>
+                </p>
 <pre xmlns:rev="http://www.cs.rpi.edu/~gregod/boost/tools/doc/revision" class="table-programlisting"><span class="keyword">struct</span> <span class="identifier">BOOST_ALIGNMENT</span><span class="special">(</span><span class="number">16</span><span class="special">)</span> <span class="identifier">my_data</span>
 <span class="special">{</span>
     <span class="keyword">char</span> <span class="identifier">c</span><span class="special">[</span><span class="number">16</span><span class="special">];</span>
 <span class="special">};</span>
 <span class="identifier">BOOST_ALIGNMENT</span><span class="special">(</span><span class="number">8</span><span class="special">)</span> <span class="keyword">int</span> <span class="identifier">arr</span><span class="special">[</span><span class="number">32</span><span class="special">];</span>
 </pre>
-<p>
-                </p>
               </td>
 </tr>
 <tr>
@@ -3255,16 +3249,14 @@
                   Some compilers don't support the use of <code class="computeroutput"><span class="keyword">constexpr</span></code>.
                   This macro expands to nothing on those compilers, and <code class="computeroutput"><span class="keyword">constexpr</span></code> elsewhere. For example,
                   when defining a constexpr function or constructor replace:
-</p>
+                </p>
 <pre xmlns:rev="http://www.cs.rpi.edu/~gregod/boost/tools/doc/revision" class="table-programlisting"><span class="keyword">constexpr</span> <span class="identifier">tuple</span><span class="special">();</span>
 </pre>
-<p>
+                <p>
                   with:
-</p>
+                </p>
 <pre xmlns:rev="http://www.cs.rpi.edu/~gregod/boost/tools/doc/revision" class="table-programlisting"><span class="identifier">BOOST_CONSTEXPR</span> <span class="identifier">tuple</span><span class="special">();</span>
 </pre>
-<p>
-                </p>
               </td>
 </tr>
 <tr>
@@ -3279,16 +3271,14 @@
                   This macro expands to <code class="computeroutput"><span class="keyword">const</span></code>
                   on those compilers, and <code class="computeroutput"><span class="keyword">constexpr</span></code>
                   elsewhere. For example, when defining const expr variables replace:
-</p>
+                </p>
 <pre xmlns:rev="http://www.cs.rpi.edu/~gregod/boost/tools/doc/revision" class="table-programlisting"><span class="keyword">static</span> <span class="keyword">constexpr</span> <span class="identifier">UIntType</span> <span class="identifier">xor_mask</span> <span class="special">=</span> <span class="identifier">a</span><span class="special">;</span>
 </pre>
-<p>
+                <p>
                   with:
-</p>
+                </p>
 <pre xmlns:rev="http://www.cs.rpi.edu/~gregod/boost/tools/doc/revision" class="table-programlisting"><span class="keyword">static</span> <span class="identifier">BOOST_CONSTEXPR_OR_CONST</span> <span class="identifier">UIntType</span> <span class="identifier">xor_mask</span> <span class="special">=</span> <span class="identifier">a</span><span class="special">;</span>
 </pre>
-<p>
-                </p>
               </td>
 </tr>
 <tr>
@@ -3302,16 +3292,14 @@
                   This is a shortcut for <code class="computeroutput"><span class="keyword">static</span>
                   <span class="identifier">BOOST_CONSTEXPR_OR_CONST</span></code>.
                   For example, when defining const expr variables replace:
-</p>
+                </p>
 <pre xmlns:rev="http://www.cs.rpi.edu/~gregod/boost/tools/doc/revision" class="table-programlisting"><span class="keyword">static</span> <span class="keyword">constexpr</span> <span class="identifier">UIntType</span> <span class="identifier">xor_mask</span> <span class="special">=</span> <span class="identifier">a</span><span class="special">;</span>
 </pre>
-<p>
+                <p>
                   with:
-</p>
+                </p>
 <pre xmlns:rev="http://www.cs.rpi.edu/~gregod/boost/tools/doc/revision" class="table-programlisting"><span class="identifier">BOOST_STATIC_CONSTEXPR</span> <span class="identifier">UIntType</span> <span class="identifier">xor_mask</span> <span class="special">=</span> <span class="identifier">a</span><span class="special">;</span>
 </pre>
-<p>
-                </p>
               </td>
 </tr>
 <tr>
@@ -3327,30 +3315,28 @@
                   not support C++11 defaulted functions the macro will expand into
                   an inline function definition with the <code class="computeroutput"><span class="identifier">body</span></code>
                   implementation. For example:
-</p>
+                </p>
 <pre xmlns:rev="http://www.cs.rpi.edu/~gregod/boost/tools/doc/revision" class="table-programlisting"><span class="keyword">struct</span> <span class="identifier">my_struct</span>
 <span class="special">{</span>
     <span class="identifier">BOOST_DEFAULTED_FUNCTION</span><span class="special">(</span><span class="identifier">my_struct</span><span class="special">(),</span> <span class="special">{})</span>
 <span class="special">};</span>
 </pre>
-<p>
+                <p>
                   is equivalent to:
-</p>
+                </p>
 <pre xmlns:rev="http://www.cs.rpi.edu/~gregod/boost/tools/doc/revision" class="table-programlisting"><span class="keyword">struct</span> <span class="identifier">my_struct</span>
 <span class="special">{</span>
     <span class="identifier">my_struct</span><span class="special">()</span> <span class="special">=</span> <span class="keyword">default</span><span class="special">;</span>
 <span class="special">};</span>
 </pre>
-<p>
+                <p>
                   or:
-</p>
+                </p>
 <pre xmlns:rev="http://www.cs.rpi.edu/~gregod/boost/tools/doc/revision" class="table-programlisting"><span class="keyword">struct</span> <span class="identifier">my_struct</span>
 <span class="special">{</span>
     <span class="identifier">my_struct</span><span class="special">()</span> <span class="special">{}</span>
 <span class="special">};</span>
 </pre>
-<p>
-                </p>
               </td>
 </tr>
 <tr>
@@ -3367,25 +3353,25 @@
                   macro will expand into a private function declaration with no definition.
                   Since the macro may change the access mode, it is recommended to
                   use this macro at the end of the class definition. For example:
-</p>
+                </p>
 <pre xmlns:rev="http://www.cs.rpi.edu/~gregod/boost/tools/doc/revision" class="table-programlisting"><span class="keyword">struct</span> <span class="identifier">noncopyable</span>
 <span class="special">{</span>
     <span class="identifier">BOOST_DELETED_FUNCTION</span><span class="special">(</span><span class="identifier">noncopyable</span><span class="special">(</span><span class="identifier">noncopyable</span> <span class="keyword">const</span><span class="special">&amp;))</span>
     <span class="identifier">BOOST_DELETED_FUNCTION</span><span class="special">(</span><span class="identifier">noncopyable</span><span class="special">&amp;</span> <span class="keyword">operator</span><span class="special">=</span> <span class="special">(</span><span class="identifier">noncopyable</span> <span class="keyword">const</span><span class="special">&amp;))</span>
 <span class="special">};</span>
 </pre>
-<p>
+                <p>
                   is equivalent to:
-</p>
+                </p>
 <pre xmlns:rev="http://www.cs.rpi.edu/~gregod/boost/tools/doc/revision" class="table-programlisting"><span class="keyword">struct</span> <span class="identifier">noncopyable</span>
 <span class="special">{</span>
     <span class="identifier">noncopyable</span><span class="special">(</span><span class="identifier">noncopyable</span> <span class="keyword">const</span><span class="special">&amp;)</span> <span class="special">=</span> <span class="keyword">delete</span><span class="special">;</span>
     <span class="identifier">noncopyable</span><span class="special">&amp;</span> <span class="keyword">operator</span><span class="special">=</span> <span class="special">(</span><span class="identifier">noncopyable</span> <span class="keyword">const</span><span class="special">&amp;)</span> <span class="special">=</span> <span class="keyword">delete</span><span class="special">;</span>
 <span class="special">};</span>
 </pre>
-<p>
+                <p>
                   or:
-</p>
+                </p>
 <pre xmlns:rev="http://www.cs.rpi.edu/~gregod/boost/tools/doc/revision" class="table-programlisting"><span class="keyword">struct</span> <span class="identifier">noncopyable</span>
 <span class="special">{</span>
 <span class="keyword">private</span><span class="special">:</span>
@@ -3393,21 +3379,15 @@
     <span class="identifier">noncopyable</span><span class="special">&amp;</span> <span class="keyword">operator</span><span class="special">=</span> <span class="special">(</span><span class="identifier">noncopyable</span> <span class="keyword">const</span><span class="special">&amp;);</span>
 <span class="special">};</span>
 </pre>
-<p>
-                </p>
               </td>
 </tr>
 <tr>
 <td>
-                <p>
-</p>
 <pre xmlns:rev="http://www.cs.rpi.edu/~gregod/boost/tools/doc/revision" class="table-programlisting"><span class="identifier">BOOST_NOEXCEPT</span>
 <span class="identifier">BOOST_NOEXCEPT_OR_NOTHROW</span>
 <span class="identifier">BOOST_NOEXCEPT_IF</span><span class="special">(</span><span class="identifier">Predicate</span><span class="special">)</span>
 <span class="identifier">BOOST_NOEXCEPT_EXPR</span><span class="special">(</span><span class="identifier">Expression</span><span class="special">)</span>
 </pre>
-<p>
-                </p>
               </td>
 <td>
                 <p>
@@ -3415,33 +3395,21 @@
                   is defined (i.e. C++03 compliant compilers) these macros are defined
                   as:
                 </p>
-                <div class="blockquote"><blockquote class="blockquote">
-<p>
-</p>
-<pre xmlns:rev="http://www.cs.rpi.edu/~gregod/boost/tools/doc/revision" class="table-programlisting"><span class="preprocessor">#define</span> <span class="identifier">BOOST_NOEXCEPT</span>
+                <div class="blockquote"><blockquote class="blockquote"><pre xmlns:rev="http://www.cs.rpi.edu/~gregod/boost/tools/doc/revision" class="table-programlisting"><span class="preprocessor">#define</span> <span class="identifier">BOOST_NOEXCEPT</span>
 <span class="preprocessor">#define</span> <span class="identifier">BOOST_NOEXCEPT_OR_NOTHROW</span> <span class="keyword">throw</span><span class="special">()</span>
 <span class="preprocessor">#define</span> <span class="identifier">BOOST_NOEXCEPT_IF</span><span class="special">(</span><span class="identifier">Predicate</span><span class="special">)</span>
 <span class="preprocessor">#define</span> <span class="identifier">BOOST_NOEXCEPT_EXPR</span><span class="special">(</span><span class="identifier">Expression</span><span class="special">)</span> <span class="keyword">false</span>
-</pre>
-<p>
-                  </p>
-</blockquote></div>
+</pre></blockquote></div>
                 <p>
                   If <code class="computeroutput"><span class="identifier">BOOST_NO_CXX11_NOEXCEPT</span></code>
                   is not defined (i.e. C++11 compliant compilers) they are defined
                   as:
                 </p>
-                <div class="blockquote"><blockquote class="blockquote">
-<p>
-</p>
-<pre xmlns:rev="http://www.cs.rpi.edu/~gregod/boost/tools/doc/revision" class="table-programlisting"><span class="preprocessor">#define</span> <span class="identifier">BOOST_NOEXCEPT</span> <span class="keyword">noexcept</span>
+                <div class="blockquote"><blockquote class="blockquote"><pre xmlns:rev="http://www.cs.rpi.edu/~gregod/boost/tools/doc/revision" class="table-programlisting"><span class="preprocessor">#define</span> <span class="identifier">BOOST_NOEXCEPT</span> <span class="keyword">noexcept</span>
 <span class="preprocessor">#define</span> <span class="identifier">BOOST_NOEXCEPT_OR_NOTHROW</span> <span class="keyword">noexcept</span>
 <span class="preprocessor">#define</span> <span class="identifier">BOOST_NOEXCEPT_IF</span><span class="special">(</span><span class="identifier">Predicate</span><span class="special">)</span> <span class="keyword">noexcept</span><span class="special">((</span><span class="identifier">Predicate</span><span class="special">))</span>
 <span class="preprocessor">#define</span> <span class="identifier">BOOST_NOEXCEPT_EXPR</span><span class="special">(</span><span class="identifier">Expression</span><span class="special">)</span> <span class="keyword">noexcept</span><span class="special">((</span><span class="identifier">Expression</span><span class="special">))</span>
-</pre>
-<p>
-                  </p>
-</blockquote></div>
+</pre></blockquote></div>
               </td>
 </tr>
 <tr>
@@ -3504,19 +3472,13 @@
                   The compiler does not support member initializer for aggregates
                   as in the following example:
                 </p>
-                <div class="blockquote"><blockquote class="blockquote">
-<p>
-</p>
-<pre xmlns:rev="http://www.cs.rpi.edu/~gregod/boost/tools/doc/revision" class="table-programlisting"><span class="keyword">struct</span> <span class="identifier">Foo</span>
+                <div class="blockquote"><blockquote class="blockquote"><pre xmlns:rev="http://www.cs.rpi.edu/~gregod/boost/tools/doc/revision" class="table-programlisting"><span class="keyword">struct</span> <span class="identifier">Foo</span>
 <span class="special">{</span>
   <span class="keyword">int</span> <span class="identifier">x</span><span class="special">,</span> <span class="identifier">y</span> <span class="special">=</span> <span class="number">42</span><span class="special">;</span>
 <span class="special">};</span>
 
 <span class="identifier">Foo</span> <span class="identifier">foo</span> <span class="special">=</span> <span class="special">{</span> <span class="number">0</span> <span class="special">};</span>
-</pre>
-<p>
-                  </p>
-</blockquote></div>
+</pre></blockquote></div>
               </td>
 </tr>
 <tr>
@@ -3671,6 +3633,762 @@
 </div>
 <div class="section">
 <div class="titlepage"><div><div><h3 class="title">
+<a name="boost_config.boost_macro_reference.macros_that_choose_standard_or_boost_libraries"></a><a class="link" href="boost_macro_reference.html#boost_config.boost_macro_reference.macros_that_choose_standard_or_boost_libraries" title="Macros that choose standard or Boost libraries">Macros
+      that choose standard or Boost libraries</a>
+</h3></div></div></div>
+<p>
+        A number of Boost libraries are also represented in the C++ standard with
+        corresponding C++ standard libraries. While the Boost and corresponding C++
+        standard library do not necessarily have exactly the same functionality they
+        are often close enough in their functionality so that either can be used
+        for particular programming tasks.
+      </p>
+<p>
+        A programmer may want to use the C++ standard version of such a library,
+        if it has been made available by the compiler implementation, rather than
+        the Boost version of the library, in order to remove a dependency in code
+        on the Boost version of such a library.
+      </p>
+<p>
+        Boost.config offers macros which allow the programmer to automatically include
+        and use the appropriate version of the library, whether C++ standard or Boost.
+      </p>
+<p>
+        These macros are not included automatically when &lt;boost/config.h&gt; is
+        included as a header file. Instead the programmer includes the appropriate
+        header file for a particular library from within the boost/config/cpp subdirectory,
+        and then makes use of macros in that header file to automatically use either
+        the C++ standard version of that library, if it is available for the particular
+        compiler implementation, or the Boost version of that library, if the C++
+        standard version is not available for the particular compiler implementation.
+      </p>
+<p>
+        For a give library 'XXX' which exists as a Boost version and may exist as
+        a C++ standard library version, the user will:
+      </p>
+<div class="itemizedlist"><ul class="itemizedlist" style="list-style-type: disc; ">
+<li class="listitem">
+            #include &lt;boost/config/cpp/XXX.hpp&gt;
+          </li>
+<li class="listitem">
+            Use BOOST_CPP_XXX_HDR in order to include the header file for that library,
+            ie. #include BOOST_CPP_XXX_HDR
+          </li>
+<li class="listitem">
+            Use the macro BOOST_CPP_XXX_NS as the namespace for that library when
+            using the functionality of that library, ie. BOOST_CPP_XXX_NS::some_library_functionality
+          </li>
+<li class="listitem">
+            If necessary use the macro BOOST_CPP_HAS_XXX to determine whether the
+            C++ standard version of the library is available or not. If BOOST_CPP_HAS_XXX
+            is 1 the C++ standard version of the library is available for use and
+            if BOOST_CPP_HAS_XXX is 0 only the Boost version of the library is available
+            for use, ie. #if BOOST_CPP_HAS_XXX for code that depends only on the
+            C++ standard version of the library or #if !BOOST_CPP_HAS_XXX for code
+            that depends only on the Boost version of the library
+          </li>
+</ul></div>
+<p>
+        The following table lists the libraries and the appropriate information for
+        each one:
+      </p>
+<div class="table">
+<a name="boost_config.boost_macro_reference.macros_that_choose_standard_or_boost_libraries.t0"></a><p class="title"><b>Table&#160;1.1.&#160;Libraries</b></p>
+<div class="table-contents"><table class="table" summary="Libraries">
+<colgroup>
+<col>
+<col>
+<col>
+<col>
+<col>
+</colgroup>
+<thead><tr>
+<th>
+                <p>
+                  Library
+                </p>
+              </th>
+<th>
+                <p>
+                  Header file
+                </p>
+              </th>
+<th>
+                <p>
+                  Include macro
+                </p>
+              </th>
+<th>
+                <p>
+                  Namespace macro
+                </p>
+              </th>
+<th>
+                <p>
+                  Check C++ standard version macro
+                </p>
+              </th>
+</tr></thead>
+<tbody>
+<tr>
+<td>
+                <p>
+                  array
+                </p>
+              </td>
+<td>
+                <p>
+                  &lt;boost/config/cpp/array.hpp&gt;
+                </p>
+              </td>
+<td>
+                <p>
+                  BOOST_CPP_ARRAY_HDR
+                </p>
+              </td>
+<td>
+                <p>
+                  BOOST_CPP_ARRAY_NS
+                </p>
+              </td>
+<td>
+                <p>
+                  BOOST_CPP_HAS_ARRAY
+                </p>
+              </td>
+</tr>
+<tr>
+<td>
+                <p>
+                  atomic
+                </p>
+              </td>
+<td>
+                <p>
+                  &lt;boost/config/cpp/atomic.hpp&gt;
+                </p>
+              </td>
+<td>
+                <p>
+                  BOOST_CPP_ATOMIC_HDR
+                </p>
+              </td>
+<td>
+                <p>
+                  BOOST_CPP_ATOMIC_NS
+                </p>
+              </td>
+<td>
+                <p>
+                  BOOST_CPP_HAS_ATOMIC
+                </p>
+              </td>
+</tr>
+<tr>
+<td>
+                <p>
+                  bind
+                </p>
+              </td>
+<td>
+                <p>
+                  &lt;boost/config/cpp/bind.hpp&gt;
+                </p>
+              </td>
+<td>
+                <p>
+                  BOOST_CPP_BIND_HDR
+                </p>
+              </td>
+<td>
+                <p>
+                  BOOST_CPP_BIND_NS
+                </p>
+              </td>
+<td>
+                <p>
+                  BOOST_CPP_HAS_BIND
+                </p>
+              </td>
+</tr>
+<tr>
+<td>
+                <p>
+                  chrono
+                </p>
+              </td>
+<td>
+                <p>
+                  &lt;boost/config/cpp/chrono.hpp&gt;
+                </p>
+              </td>
+<td>
+                <p>
+                  BOOST_CPP_CHRONO_HDR
+                </p>
+              </td>
+<td>
+                <p>
+                  BOOST_CPP_CHRONO_NS
+                </p>
+              </td>
+<td>
+                <p>
+                  BOOST_CPP_HAS_CHRONO
+                </p>
+              </td>
+</tr>
+<tr>
+<td>
+                <p>
+                  function
+                </p>
+              </td>
+<td>
+                <p>
+                  &lt;boost/config/cpp/function.hpp&gt;
+                </p>
+              </td>
+<td>
+                <p>
+                  BOOST_CPP_FUNCTION_HDR
+                </p>
+              </td>
+<td>
+                <p>
+                  BOOST_CPP_FUNCTION_NS
+                </p>
+              </td>
+<td>
+                <p>
+                  BOOST_CPP_HAS_FUNCTION
+                </p>
+              </td>
+</tr>
+<tr>
+<td>
+                <p>
+                  hash
+                </p>
+              </td>
+<td>
+                <p>
+                  &lt;boost/config/cpp/hash.hpp&gt;
+                </p>
+              </td>
+<td>
+                <p>
+                  BOOST_CPP_HASH_HDR
+                </p>
+              </td>
+<td>
+                <p>
+                  BOOST_CPP_HASH_NS
+                </p>
+              </td>
+<td>
+                <p>
+                  BOOST_CPP_HAS_HASH
+                </p>
+              </td>
+</tr>
+<tr>
+<td>
+                <p>
+                  mem_fn
+                </p>
+              </td>
+<td>
+                <p>
+                  &lt;boost/config/cpp/mem_fn.hpp&gt;
+                </p>
+              </td>
+<td>
+                <p>
+                  BOOST_CPP_MEM_FN_HDR
+                </p>
+              </td>
+<td>
+                <p>
+                  BOOST_CPP_MEM_FN_NS
+                </p>
+              </td>
+<td>
+                <p>
+                  BOOST_CPP_HAS_MEM_FN
+                </p>
+              </td>
+</tr>
+<tr>
+<td>
+                <p>
+                  random
+                </p>
+              </td>
+<td>
+                <p>
+                  &lt;boost/config/cpp/random.hpp&gt;
+                </p>
+              </td>
+<td>
+                <p>
+                  BOOST_CPP_RANDOM_HDR
+                </p>
+              </td>
+<td>
+                <p>
+                  BOOST_CPP_RANDOM_NS
+                </p>
+              </td>
+<td>
+                <p>
+                  BOOST_CPP_HAS_RANDOM
+                </p>
+              </td>
+</tr>
+<tr>
+<td>
+                <p>
+                  ratio
+                </p>
+              </td>
+<td>
+                <p>
+                  &lt;boost/config/cpp/ratio.hpp&gt;
+                </p>
+              </td>
+<td>
+                <p>
+                  BOOST_CPP_RATIO_HDR
+                </p>
+              </td>
+<td>
+                <p>
+                  BOOST_CPP_RATIO_NS
+                </p>
+              </td>
+<td>
+                <p>
+                  BOOST_CPP_HAS_RATIO
+                </p>
+              </td>
+</tr>
+<tr>
+<td>
+                <p>
+                  ref
+                </p>
+              </td>
+<td>
+                <p>
+                  &lt;boost/config/cpp/ref.hpp&gt;
+                </p>
+              </td>
+<td>
+                <p>
+                  BOOST_CPP_REF_HDR
+                </p>
+              </td>
+<td>
+                <p>
+                  BOOST_CPP_REF_NS
+                </p>
+              </td>
+<td>
+                <p>
+                  BOOST_CPP_HAS_REF
+                </p>
+              </td>
+</tr>
+<tr>
+<td>
+                <p>
+                  regex
+                </p>
+              </td>
+<td>
+                <p>
+                  &lt;boost/config/cpp/regex.hpp&gt;
+                </p>
+              </td>
+<td>
+                <p>
+                  BOOST_CPP_REGEX_HDR
+                </p>
+              </td>
+<td>
+                <p>
+                  BOOST_CPP_REGEX_NS
+                </p>
+              </td>
+<td>
+                <p>
+                  BOOST_CPP_HAS_REGEX
+                </p>
+              </td>
+</tr>
+<tr>
+<td>
+                <p>
+                  shared_ptr
+                </p>
+              </td>
+<td>
+                <p>
+                  &lt;boost/config/cpp/shared_ptr.hpp&gt;
+                </p>
+              </td>
+<td>
+                <p>
+                  BOOST_CPP_SHARED_PTR_HDR
+                </p>
+              </td>
+<td>
+                <p>
+                  BOOST_CPP_SHARED_PTR_NS
+                </p>
+              </td>
+<td>
+                <p>
+                  BOOST_CPP_HAS_SHARED_PTR
+                </p>
+              </td>
+</tr>
+<tr>
+<td>
+                <p>
+                  thread
+                </p>
+              </td>
+<td>
+                <p>
+                  &lt;boost/config/cpp/thread.hpp&gt;
+                </p>
+              </td>
+<td>
+                <p>
+                  BOOST_CPP_THREAD_HDR
+                </p>
+              </td>
+<td>
+                <p>
+                  BOOST_CPP_THREAD_NS
+                </p>
+              </td>
+<td>
+                <p>
+                  BOOST_CPP_HAS_THREAD
+                </p>
+              </td>
+</tr>
+<tr>
+<td>
+                <p>
+                  tuple
+                </p>
+              </td>
+<td>
+                <p>
+                  &lt;boost/config/cpp/tuple.hpp&gt;
+                </p>
+              </td>
+<td>
+                <p>
+                  BOOST_CPP_TUPLE_HDR
+                </p>
+              </td>
+<td>
+                <p>
+                  BOOST_CPP_TUPLE_NS
+                </p>
+              </td>
+<td>
+                <p>
+                  BOOST_CPP_HAS_TUPLE
+                </p>
+              </td>
+</tr>
+<tr>
+<td>
+                <p>
+                  type_index
+                </p>
+              </td>
+<td>
+                <p>
+                  &lt;boost/config/cpp/type_index.hpp&gt;
+                </p>
+              </td>
+<td>
+                <p>
+                  BOOST_CPP_TYPE_INDEX_HDR
+                </p>
+              </td>
+<td>
+                <p>
+                  BOOST_CPP_TYPE_INDEX_NS
+                </p>
+              </td>
+<td>
+                <p>
+                  BOOST_CPP_HAS_TYPE_INDEX
+                </p>
+              </td>
+</tr>
+<tr>
+<td>
+                <p>
+                  type_traits
+                </p>
+              </td>
+<td>
+                <p>
+                  &lt;boost/config/cpp/type_traits.hpp&gt;
+                </p>
+              </td>
+<td>
+                <p>
+                  BOOST_CPP_TYPE_TRAITS_HDR
+                </p>
+              </td>
+<td>
+                <p>
+                  BOOST_CPP_TYPE_TRAITS_NS
+                </p>
+              </td>
+<td>
+                <p>
+                  BOOST_CPP_HAS_TYPE_TRAITS
+                </p>
+              </td>
+</tr>
+<tr>
+<td>
+                <p>
+                  unordered_map
+                </p>
+              </td>
+<td>
+                <p>
+                  &lt;boost/config/cpp/unordered_map.hpp&gt;
+                </p>
+              </td>
+<td>
+                <p>
+                  BOOST_CPP_UNORDERED_MAP_HDR
+                </p>
+              </td>
+<td>
+                <p>
+                  BOOST_CPP_UNORDERED_MAP_NS
+                </p>
+              </td>
+<td>
+                <p>
+                  BOOST_CPP_HAS_UNORDERED_MAP
+                </p>
+              </td>
+</tr>
+<tr>
+<td>
+                <p>
+                  unordered_multimap
+                </p>
+              </td>
+<td>
+                <p>
+                  &lt;boost/config/cpp/unordered_multimap.hpp&gt;
+                </p>
+              </td>
+<td>
+                <p>
+                  BOOST_CPP_UNORDERED_MULTIMAP_HDR
+                </p>
+              </td>
+<td>
+                <p>
+                  BOOST_CPP_UNORDERED_MULTIMAP_NS
+                </p>
+              </td>
+<td>
+                <p>
+                  BOOST_CPP_HAS_UNORDERED_MULTIMAP
+                </p>
+              </td>
+</tr>
+<tr>
+<td>
+                <p>
+                  unordered_multiset
+                </p>
+              </td>
+<td>
+                <p>
+                  &lt;boost/config/cpp/unordered_multiset.hpp&gt;
+                </p>
+              </td>
+<td>
+                <p>
+                  BOOST_CPP_UNORDERED_MULTISET_HDR
+                </p>
+              </td>
+<td>
+                <p>
+                  BOOST_CPP_UNORDERED_MULTISET_NS
+                </p>
+              </td>
+<td>
+                <p>
+                  BOOST_CPP_HAS_UNORDERED_MULTISET
+                </p>
+              </td>
+</tr>
+<tr>
+<td>
+                <p>
+                  unordered_set
+                </p>
+              </td>
+<td>
+                <p>
+                  &lt;boost/config/cpp/unordered_set.hpp&gt;
+                </p>
+              </td>
+<td>
+                <p>
+                  BOOST_CPP_UNORDERED_SET_HDR
+                </p>
+              </td>
+<td>
+                <p>
+                  BOOST_CPP_UNORDERED_SET_NS
+                </p>
+              </td>
+<td>
+                <p>
+                  BOOST_CPP_HAS_UNORDERED_SET
+                </p>
+              </td>
+</tr>
+</tbody>
+</table></div>
+</div>
+<br class="table-break"><h5>
+<a name="boost_config.boost_macro_reference.macros_that_choose_standard_or_boost_libraries.h0"></a>
+        <span class="phrase"><a name="boost_config.boost_macro_reference.macros_that_choose_standard_or_boost_libraries.using_the_macros_"></a></span><a class="link" href="boost_macro_reference.html#boost_config.boost_macro_reference.macros_that_choose_standard_or_boost_libraries.using_the_macros_">Using
+        the macros </a>
+      </h5>
+<p>
+        The general form of using these macros in a translation unit will now be
+        given, choosing the regex library as an example.
+      </p>
+<pre class="programlisting"><span class="preprocessor">#include</span> <span class="special">&lt;</span><span class="identifier">boost</span><span class="special">/</span><span class="identifier">config</span><span class="special">/</span><span class="identifier">cpp</span><span class="special">/</span><span class="identifier">regex</span><span class="special">.</span><span class="identifier">hpp</span><span class="special">&gt;</span>
+<span class="preprocessor">#include</span> <span class="identifier">BOOST_CPP_REGEX_HDR</span>
+
+<span class="keyword">void</span> <span class="identifier">SomeFunction</span><span class="special">()</span>
+  <span class="special">{</span>
+  <span class="identifier">BOOST_CPP_REGEX_NS</span><span class="special">::</span><span class="identifier">regex</span> <span class="identifier">re</span><span class="special">(</span><span class="string">"A regular expression etc."</span><span class="special">);</span>
+  <span class="keyword">bool</span> <span class="identifier">result</span><span class="special">(</span><span class="identifier">BOOST_CPP_REGEX_NS</span><span class="special">::</span><span class="identifier">regex_match</span><span class="special">(</span><span class="string">"Some string..."</span><span class="special">,</span><span class="identifier">re</span><span class="special">));</span>
+  <span class="comment">// etc.</span>
+  <span class="special">}</span>
+</pre>
+<p>
+        In the example the code will work whether we are using the C++ standard regex
+        library or the Boost regex library.
+      </p>
+<h5>
+<a name="boost_config.boost_macro_reference.macros_that_choose_standard_or_boost_libraries.h1"></a>
+        <span class="phrase"><a name="boost_config.boost_macro_reference.macros_that_choose_standard_or_boost_libraries.using_the_boost_cpp_has_____macro_"></a></span><a class="link" href="boost_macro_reference.html#boost_config.boost_macro_reference.macros_that_choose_standard_or_boost_libraries.using_the_boost_cpp_has_____macro_">Using
+        the BOOST_CPP_HAS_... macro </a>
+      </h5>
+<p>
+        The BOOST_CPP_HAS_ macro for any given library is a more understandable form
+        of macro than Boost.config already has for determining whether the compiler
+        supports certain C++ libraries. Most of these macros are taken from whether
+        or not a given BOOST_NO_CXX11_HDR_ is defined. You can use a BOOST_CPP_HAS_
+        macro to discover whether a Boost library is also supported by an equivalent
+        C++ standard library.
+      </p>
+<p>
+        You may decide you need the C++ standard version of a particular library,
+        rather than the Boost version, or else you do not want your code to compile.
+        As an example let's say that you want to create a compile error if the compiler
+        does not support the C++ standard library type_traits library, even though
+        the Boost type_traits library could also normally be used.
+      </p>
+<pre class="programlisting"><span class="preprocessor">#include</span> <span class="special">&lt;</span><span class="identifier">boost</span><span class="special">/</span><span class="identifier">config</span><span class="special">/</span><span class="identifier">cpp</span><span class="special">/</span><span class="identifier">type_traits</span><span class="special">.</span><span class="identifier">hpp</span><span class="special">&gt;</span>
+<span class="preprocessor">#if</span> <span class="special">!</span><span class="identifier">BOOST_CPP_HAS_TYPE_TRAITS</span>
+<span class="preprocessor">#error</span> <span class="identifier">C</span><span class="special">++</span> <span class="identifier">standard</span> <span class="identifier">type_traits</span> <span class="identifier">library</span> <span class="identifier">needed</span> <span class="keyword">and</span> <span class="keyword">not</span> <span class="identifier">present</span><span class="special">.</span>
+<span class="preprocessor">#endif</span>
+
+<span class="comment">// Further code</span>
+</pre>
+<p>
+        Another use for the BOOST_CPP_HAS_ macro is to include particular header
+        files rather than a main header file, for some given library functionality.
+        This is more prevalent with Boost than with the C++ standard library, the
+        latter almost always having a single header file which includes library functionality
+        for all parts of a library.
+      </p>
+<pre class="programlisting"><span class="preprocessor">#include</span> <span class="special">&lt;</span><span class="identifier">boost</span><span class="special">/</span><span class="identifier">config</span><span class="special">/</span><span class="identifier">cpp</span><span class="special">/</span><span class="identifier">type_traits</span><span class="special">.</span><span class="identifier">hpp</span><span class="special">&gt;</span>
+<span class="preprocessor">#if</span> <span class="identifier">BOOST_CPP_HAS_TYPE_TRAITS</span>
+<span class="preprocessor">#include</span> <span class="identifier">BOOST_CPP_TYPE_TRAITS_HDR</span>
+<span class="preprocessor">#else</span>
+<span class="preprocessor">#include</span> <span class="special">&lt;</span><span class="identifier">boost</span><span class="special">/</span><span class="identifier">type_traits</span><span class="special">/</span><span class="identifier">add_const</span><span class="special">.</span><span class="identifier">hpp</span><span class="special">&gt;</span>
+<span class="preprocessor">#endif</span>
+
+<span class="comment">// Further code using BOOST_CPP_TYPE_TRAITS_NS::add_const</span>
+</pre>
+<p>
+        You can also use the BOOST_CPP_HAS_ macro to provide specific functionality
+        depending on whether or not a particular library is using the C++ standard
+        or Boost version. Of course you hope to minimize these situations but occasionally
+        they happen:
+      </p>
+<pre class="programlisting"><span class="preprocessor">#include</span> <span class="special">&lt;</span><span class="identifier">boost</span><span class="special">/</span><span class="identifier">config</span><span class="special">/</span><span class="identifier">cpp</span><span class="special">/</span><span class="identifier">thread</span><span class="special">.</span><span class="identifier">hpp</span><span class="special">&gt;</span>
+<span class="preprocessor">#include</span> <span class="identifier">BOOST_CPP_THREAD_HDR</span>
+
+<span class="comment">// Code...</span>
+
+<span class="preprocessor">#if</span> <span class="identifier">BOOST_CPP_HAS_THREAD</span>
+
+<span class="comment">// Functionality available if the C++ standard version of the thread library is being used</span>
+
+<span class="preprocessor">#else</span>
+
+<span class="comment">// Functionality available if the Boost version of the thread library is being used</span>
+
+<span class="preprocessor">#endif</span>
+</pre>
+<h5>
+<a name="boost_config.boost_macro_reference.macros_that_choose_standard_or_boost_libraries.h2"></a>
+        <span class="phrase"><a name="boost_config.boost_macro_reference.macros_that_choose_standard_or_boost_libraries.library_header_file_dependency_"></a></span><a class="link" href="boost_macro_reference.html#boost_config.boost_macro_reference.macros_that_choose_standard_or_boost_libraries.library_header_file_dependency_">Library
+        header file dependency </a>
+      </h5>
+<p>
+        When the programmer includes the appropriate header file for a particular
+        library from within the boost/config/cpp subdirectory there is no dependency
+        being established on the library itself. Any one of the library header files
+        merely defines macros which the programmer may choose to use or not.
+      </p>
+<p>
+        It is only when using a particular include macro, along with a particular
+        namespace macro, from any given library that a dependency is established.
+      </p>
+<p>
+        Because of this it has been made possible to include all library headers
+        with a single include:
+      </p>
+<pre class="programlisting"><span class="preprocessor">#include</span> <span class="special">&lt;</span><span class="identifier">boost</span><span class="special">/</span><span class="identifier">config</span><span class="special">/</span><span class="identifier">cpp</span><span class="special">.</span><span class="identifier">h</span><span class="special">&gt;</span>
+</pre>
+<p>
+        This includes macros for each library, starting with BOOST_CPP_, but as long
+        as the prefix BOOST_CPP_ does not conflict with macros from any other software
+        library in the translation unit there should be no problems.
+      </p>
+</div>
+<div class="section">
+<div class="titlepage"><div><div><h3 class="title">
 <a name="boost_config.boost_macro_reference.boost_helper_macros"></a><a name="config_helpers"></a><a class="link" href="boost_macro_reference.html#boost_config.boost_macro_reference.boost_helper_macros" title="Boost Helper Macros">Boost
       Helper Macros</a>
 </h3></div></div></div>
@@ -3707,19 +4425,19 @@
                   This macro is used where a compiler specific workaround is required
                   that is not otherwise described by one of the other Boost.Config
                   macros. To use the macro you must first
-</p>
+                </p>
 <pre xmlns:rev="http://www.cs.rpi.edu/~gregod/boost/tools/doc/revision" class="table-programlisting"><span class="preprocessor">#include</span> <span class="special">&lt;</span><span class="identifier">boost</span><span class="special">/</span><span class="identifier">detail</span><span class="special">/</span><span class="identifier">workaround</span><span class="special">.</span><span class="identifier">hpp</span><span class="special">&gt;</span>
 </pre>
-<p>
+                <p>
                   usage is then:
-</p>
+                </p>
 <pre xmlns:rev="http://www.cs.rpi.edu/~gregod/boost/tools/doc/revision" class="table-programlisting"><span class="preprocessor">#if</span> <span class="identifier">BOOST_WORKAROUND</span><span class="special">(</span><span class="identifier">MACRONAME</span><span class="special">,</span> <span class="identifier">CONDITION</span><span class="special">)</span>
    <span class="comment">// workaround code goes here...</span>
 <span class="preprocessor">#else</span>
    <span class="comment">// Standard conforming code goes here...</span>
 <span class="preprocessor">#endif</span>
 </pre>
-<p>
+                <p>
                   where <code class="computeroutput"><span class="identifier">MACRONAME</span></code>
                   is a macro that usually describes the version number to be tested
                   against, and <code class="computeroutput"><span class="identifier">CONDITION</span></code>
@@ -3755,16 +4473,14 @@
                   for example "min" and "max" member functions,
                   in which case one can prevent the function being expanded as a
                   macro using:
-</p>
+                </p>
 <pre xmlns:rev="http://www.cs.rpi.edu/~gregod/boost/tools/doc/revision" class="table-programlisting"><span class="identifier">someclass</span><span class="special">.</span><span class="identifier">min</span> <span class="identifier">BOOST_PREVENT_MACRO_SUBSTITUTION</span><span class="special">(</span><span class="identifier">arg1</span><span class="special">,</span> <span class="identifier">arg2</span><span class="special">);</span>
 </pre>
-<p>
+                <p>
                   The following also works in most, but not all, contexts:
-</p>
+                </p>
 <pre xmlns:rev="http://www.cs.rpi.edu/~gregod/boost/tools/doc/revision" class="table-programlisting"><span class="special">(</span><span class="identifier">someclass</span><span class="special">.</span><span class="identifier">max</span><span class="special">)(</span><span class="identifier">arg1</span><span class="special">,</span> <span class="identifier">arg2</span><span class="special">);</span>
 </pre>
-<p>
-                </p>
               </td>
 </tr>
 <tr>
@@ -3855,20 +4571,18 @@
                   we want the constants to be available at compile-time. This macro
                   gives us a convenient way to declare such constants. For example
                   instead of:
-</p>
+                </p>
 <pre xmlns:rev="http://www.cs.rpi.edu/~gregod/boost/tools/doc/revision" class="table-programlisting"><span class="keyword">struct</span> <span class="identifier">foo</span><span class="special">{</span>
    <span class="keyword">static</span> <span class="keyword">const</span> <span class="keyword">int</span> <span class="identifier">value</span> <span class="special">=</span> <span class="number">2</span><span class="special">;</span>
 <span class="special">};</span>
 </pre>
-<p>
+                <p>
                   use:
-</p>
+                </p>
 <pre xmlns:rev="http://www.cs.rpi.edu/~gregod/boost/tools/doc/revision" class="table-programlisting"><span class="keyword">struct</span> <span class="identifier">foo</span><span class="special">{</span>
    <span class="identifier">BOOST_STATIC_CONSTANT</span><span class="special">(</span><span class="keyword">int</span><span class="special">,</span> <span class="identifier">value</span> <span class="special">=</span> <span class="number">2</span><span class="special">);</span>
 <span class="special">};</span>
 </pre>
-<p>
-                </p>
               </td>
 </tr>
 <tr>
@@ -3894,7 +4608,7 @@
                 <p>
                   The BOOST_FALLTHROUGH macro can be used to annotate implicit fall-through
                   between switch labels:
-</p>
+                </p>
 <pre xmlns:rev="http://www.cs.rpi.edu/~gregod/boost/tools/doc/revision" class="table-programlisting"><span class="keyword">switch</span> <span class="special">(</span><span class="identifier">x</span><span class="special">)</span> <span class="special">{</span>
 <span class="keyword">case</span> <span class="number">40</span><span class="special">:</span>
 <span class="keyword">case</span> <span class="number">41</span><span class="special">:</span>
@@ -3908,7 +4622,7 @@
    <span class="keyword">case</span> <span class="number">42</span><span class="special">:</span>
       <span class="special">...</span>
 </pre>
-<p>
+                <p>
                   As shown in the example above, the BOOST_FALLTHROUGH macro should
                   be followed by a semicolon. It is designed to mimic control-flow
                   statements like 'break;', so it can be placed in most places where
@@ -3943,7 +4657,7 @@
                   Some compilers silently "fold" different function template
                   instantiations if some of the template parameters don't appear
                   in the function parameter list. For instance:
-</p>
+                </p>
 <pre xmlns:rev="http://www.cs.rpi.edu/~gregod/boost/tools/doc/revision" class="table-programlisting"><span class="preprocessor">#include</span> <span class="special">&lt;</span><span class="identifier">iostream</span><span class="special">&gt;</span>
 <span class="preprocessor">#include</span> <span class="special">&lt;</span><span class="identifier">ostream</span><span class="special">&gt;</span>
 <span class="preprocessor">#include</span> <span class="special">&lt;</span><span class="identifier">typeinfo</span><span class="special">&gt;</span>
@@ -3962,19 +4676,19 @@
   <span class="identifier">g</span><span class="special">&lt;</span><span class="keyword">double</span><span class="special">&gt;();</span>
 <span class="special">}</span>
 </pre>
-<p>
+                <p>
                   incorrectly outputs <code class="literal">2 2 double double</code> on VC++
                   6. These macros, to be used in the function parameter list, fix
                   the problem without effects on the calling syntax. For instance,
                   in the case above write:
-</p>
+                </p>
 <pre xmlns:rev="http://www.cs.rpi.edu/~gregod/boost/tools/doc/revision" class="table-programlisting"><span class="keyword">template</span> <span class="special">&lt;</span><span class="keyword">int</span> <span class="identifier">n</span><span class="special">&gt;</span>
 <span class="keyword">void</span> <span class="identifier">f</span><span class="special">(</span><span class="identifier">BOOST_EXPLICIT_TEMPLATE_NON_TYPE</span><span class="special">(</span><span class="keyword">int</span><span class="special">,</span> <span class="identifier">n</span><span class="special">))</span> <span class="special">{</span> <span class="special">...</span> <span class="special">}</span>
 
 <span class="keyword">template</span> <span class="special">&lt;</span><span class="keyword">typename</span> <span class="identifier">T</span><span class="special">&gt;</span>
 <span class="keyword">void</span> <span class="identifier">g</span><span class="special">(</span><span class="identifier">BOOST_EXPLICIT_TEMPLATE_TYPE</span><span class="special">(</span><span class="identifier">T</span><span class="special">))</span> <span class="special">{</span> <span class="special">...</span> <span class="special">}</span>
 </pre>
-<p>
+                <p>
                   Beware that they can declare (for affected compilers) a dummy defaulted
                   parameter, so they
                 </p>
@@ -4093,15 +4807,13 @@
                 </p>
                 <p>
                   Usage example:
-</p>
+                </p>
 <pre xmlns:rev="http://www.cs.rpi.edu/~gregod/boost/tools/doc/revision" class="table-programlisting"><span class="keyword">template</span><span class="special">&lt;</span><span class="keyword">class</span> <span class="identifier">T</span><span class="special">&gt;</span>
 <span class="identifier">BOOST_FORCEINLINE</span> <span class="identifier">T</span><span class="special">&amp;</span> <span class="identifier">f</span><span class="special">(</span><span class="identifier">T</span><span class="special">&amp;</span> <span class="identifier">t</span><span class="special">)</span>
 <span class="special">{</span>
     <span class="keyword">return</span> <span class="identifier">t</span><span class="special">;</span>
 <span class="special">}</span>
 </pre>
-<p>
-                </p>
                 <p>
                   Note that use of this macro can lead to cryptic error messages
                   with some compilers. Consider defining it to <code class="computeroutput"><span class="keyword">inline</span></code>
@@ -4125,14 +4837,12 @@
                 </p>
                 <p>
                   Usage example:
-</p>
+                </p>
 <pre xmlns:rev="http://www.cs.rpi.edu/~gregod/boost/tools/doc/revision" class="table-programlisting"><span class="identifier">BOOST_NOINLINE</span> <span class="keyword">void</span> <span class="identifier">handle_error</span><span class="special">(</span><span class="keyword">const</span> <span class="keyword">char</span><span class="special">*</span> <span class="identifier">descr</span><span class="special">)</span>
 <span class="special">{</span>
     <span class="comment">// ...</span>
 <span class="special">}</span>
 </pre>
-<p>
-                </p>
               </td>
 </tr>
 <tr>
@@ -4156,14 +4866,12 @@
                 </p>
                 <p>
                   Usage example:
-</p>
+                </p>
 <pre xmlns:rev="http://www.cs.rpi.edu/~gregod/boost/tools/doc/revision" class="table-programlisting"><span class="identifier">BOOST_NORETURN</span> <span class="keyword">void</span> <span class="identifier">on_error_occurred</span><span class="special">(</span><span class="keyword">const</span> <span class="keyword">char</span><span class="special">*</span> <span class="identifier">descr</span><span class="special">)</span>
 <span class="special">{</span>
     <span class="keyword">throw</span> <span class="identifier">std</span><span class="special">::</span><span class="identifier">runtime_error</span><span class="special">(</span><span class="identifier">descr</span><span class="special">);</span>
 <span class="special">}</span>
 </pre>
-<p>
-                </p>
                 <p>
                   If the compiler does not support this markup, <code class="computeroutput"><span class="identifier">BOOST_NORETURN</span></code>
                   is defined empty and an additional macro <code class="computeroutput"><span class="identifier">BOOST_NO_NORETURN</span></code>
@@ -4193,12 +4901,10 @@
                 </p>
                 <p>
                   Usage example:
-</p>
+                </p>
 <pre xmlns:rev="http://www.cs.rpi.edu/~gregod/boost/tools/doc/revision" class="table-programlisting"><span class="keyword">if</span> <span class="special">(</span><span class="identifier">BOOST_UNLIKELY</span><span class="special">(</span><span class="identifier">ptr</span> <span class="special">==</span> <span class="identifier">NULL</span><span class="special">))</span>
   <span class="identifier">handle_error</span><span class="special">(</span><span class="string">"ptr is NULL"</span><span class="special">);</span>
 </pre>
-<p>
-                </p>
               </td>
 </tr>
 <tr>
@@ -5694,10 +6400,10 @@
                     as exceptions or used in dynamic_casts, across shared library
                     boundaries. For example, a header-only exception class might
                     look like this:
-</p>
+                  </p>
 <pre xmlns:rev="http://www.cs.rpi.edu/~gregod/boost/tools/doc/revision" class="table-programlisting"><span class="keyword">class</span> <span class="identifier">BOOST_SYMBOL_VISIBLE</span> <span class="identifier">my_exception</span> <span class="special">:</span> <span class="keyword">public</span> <span class="identifier">std</span><span class="special">::</span><span class="identifier">runtime_error</span> <span class="special">{</span> <span class="special">...</span> <span class="special">};</span>
 </pre>
-<p>
+                  <p>
                     Without BOOST_SYMBOL_VISIBLE, it would be impossible to catch
                     my_exception thrown from a shared library compiled by GCC with
                     the -fvisibility=hidden option.

--- a/doc/html/boost_config/boost_macro_reference.html
+++ b/doc/html/boost_config/boost_macro_reference.html
@@ -4273,7 +4273,18 @@
 </tbody>
 </table></div>
 </div>
-<br class="table-break"><h5>
+<br class="table-break"><p>
+        Not mentioned or listed above is a macro of the form BOOST_CPP_XXX_MACRO,
+        which is only defined for a library XXX which has equivalent macro names
+        between the C++ standard library version and the Boost library version. This
+        macro is used in the form of BOOST_CPP_XXX_MACRO(MACRO_NAME) to produce the
+        correct macro name for the equivalent macro no matter which implementation
+        is being used. Currently, among the libraries listed above, the only library
+        which uses this form is the 'atomic' library. It's name therefore is BOOST_CPP_ATOMIC_MACRO
+        and it can be used in the form of BOOST_CPP_ATOMIC_MACRO(AN_ATOMIC_MACRO)
+        to produce the correct equivalent macro name for the 'atomic' library.
+      </p>
+<h5>
 <a name="boost_config.boost_macro_reference.macros_that_choose_standard_or_boost_libraries.h0"></a>
         <span class="phrase"><a name="boost_config.boost_macro_reference.macros_that_choose_standard_or_boost_libraries.using_the_macros_"></a></span><a class="link" href="boost_macro_reference.html#boost_config.boost_macro_reference.macros_that_choose_standard_or_boost_libraries.using_the_macros_">Using
         the macros </a>

--- a/doc/html/boost_config/build_config.html
+++ b/doc/html/boost_config/build_config.html
@@ -4,8 +4,8 @@
 <title>Build Time Configuration</title>
 <link rel="stylesheet" href="../../../../../doc/src/boostbook.css" type="text/css">
 <meta name="generator" content="DocBook XSL Stylesheets V1.78.1">
-<link rel="home" href="../index.html" title="Boost.Config">
-<link rel="up" href="../index.html" title="Boost.Config">
+<link rel="home" href="../index.html" title="Chapter&#160;1.&#160;Boost.Config">
+<link rel="up" href="../index.html" title="Chapter&#160;1.&#160;Boost.Config">
 <link rel="prev" href="boost_macro_reference.html" title="Boost Macro Reference">
 <link rel="next" href="cstdint.html" title="Standard Integer Types">
 </head>

--- a/doc/html/boost_config/cstdint.html
+++ b/doc/html/boost_config/cstdint.html
@@ -4,8 +4,8 @@
 <title>Standard Integer Types</title>
 <link rel="stylesheet" href="../../../../../doc/src/boostbook.css" type="text/css">
 <meta name="generator" content="DocBook XSL Stylesheets V1.78.1">
-<link rel="home" href="../index.html" title="Boost.Config">
-<link rel="up" href="../index.html" title="Boost.Config">
+<link rel="home" href="../index.html" title="Chapter&#160;1.&#160;Boost.Config">
+<link rel="up" href="../index.html" title="Chapter&#160;1.&#160;Boost.Config">
 <link rel="prev" href="build_config.html" title="Build Time Configuration">
 <link rel="next" href="guidelines_for_boost_authors.html" title="Guidelines for Boost Authors">
 </head>

--- a/doc/html/boost_config/guidelines_for_boost_authors.html
+++ b/doc/html/boost_config/guidelines_for_boost_authors.html
@@ -4,8 +4,8 @@
 <title>Guidelines for Boost Authors</title>
 <link rel="stylesheet" href="../../../../../doc/src/boostbook.css" type="text/css">
 <meta name="generator" content="DocBook XSL Stylesheets V1.78.1">
-<link rel="home" href="../index.html" title="Boost.Config">
-<link rel="up" href="../index.html" title="Boost.Config">
+<link rel="home" href="../index.html" title="Chapter&#160;1.&#160;Boost.Config">
+<link rel="up" href="../index.html" title="Chapter&#160;1.&#160;Boost.Config">
 <link rel="prev" href="cstdint.html" title="Standard Integer Types">
 <link rel="next" href="rationale.html" title="Rationale">
 </head>

--- a/doc/html/boost_config/macros_that_choose_standard_or_boost_libraries.html
+++ b/doc/html/boost_config/macros_that_choose_standard_or_boost_libraries.html
@@ -1,0 +1,791 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=US-ASCII">
+<title>Macros that choose standard or Boost libraries</title>
+<link rel="stylesheet" href="../../../../../doc/src/boostbook.css" type="text/css">
+<meta name="generator" content="DocBook XSL Stylesheets V1.78.1">
+<link rel="home" href="../index.html" title="Chapter&#160;1.&#160;Boost.Config">
+<link rel="up" href="../index.html" title="Chapter&#160;1.&#160;Boost.Config">
+<link rel="prev" href="acknowledgements.html" title="Acknowledgements">
+</head>
+<body bgcolor="white" text="black" link="#0000FF" vlink="#840084" alink="#0000FF">
+<table cellpadding="2" width="100%"><tr>
+<td valign="top"><img alt="Boost C++ Libraries" width="277" height="86" src="../../../../../boost.png"></td>
+<td align="center"><a href="../../../../../index.html">Home</a></td>
+<td align="center"><a href="../../../../../libs/libraries.htm">Libraries</a></td>
+<td align="center"><a href="http://www.boost.org/users/people.html">People</a></td>
+<td align="center"><a href="http://www.boost.org/users/faq.html">FAQ</a></td>
+<td align="center"><a href="../../../../../more/index.htm">More</a></td>
+</tr></table>
+<hr>
+<div class="spirit-nav">
+<a accesskey="p" href="acknowledgements.html"><img src="../../../../../doc/src/images/prev.png" alt="Prev"></a><a accesskey="u" href="../index.html"><img src="../../../../../doc/src/images/up.png" alt="Up"></a><a accesskey="h" href="../index.html"><img src="../../../../../doc/src/images/home.png" alt="Home"></a>
+</div>
+<div class="section">
+<div class="titlepage"><div><div><h2 class="title" style="clear: both">
+<a name="boost_config.macros_that_choose_standard_or_boost_libraries"></a><a class="link" href="macros_that_choose_standard_or_boost_libraries.html" title="Macros that choose standard or Boost libraries">Macros
+    that choose standard or Boost libraries</a>
+</h2></div></div></div>
+<p>
+      A number of Boost libraries are also represented in the C++ standard with corresponding
+      C++ standard libraries. While the Boost and corresponding C++ standard library
+      do not necessarily have exactly the same functionality they are often close
+      enough in their functionality so that either can be used for particular programming
+      tasks.
+    </p>
+<p>
+      A programmer may want to use the C++ standard version of such a library, if
+      it has been made available by the compiler implementation, rather than the
+      Boost version of the library, in order to remove a dependency in code on the
+      Boost version of such a library.
+    </p>
+<p>
+      Boost.config offers macros which allow the programmer to automatically include
+      and use the appropriate version of the library, whether C++ standard or Boost.
+    </p>
+<p>
+      These macros are not included automatically when &lt;boost/config.h&gt; is
+      included as a header file. Instead the programmer includes the appropriate
+      header file for a particular library from within the boost/config/cpp subdirectory,
+      and then makes use of macros in that header file to automatically use either
+      the C++ standard version of that library, if it is available for the particulat
+      compiler implementation, or the Boost version of that library, if the C++ standard
+      version is not available for the particular compiler implementation.
+    </p>
+<p>
+      For a give library 'XXX' which exists as a Boost version and may exist as a
+      C++ standard library version, the user will:
+    </p>
+<div class="itemizedlist"><ul class="itemizedlist" style="list-style-type: disc; ">
+<li class="listitem">
+          #include &lt;boost/config/cpp/XXX.hpp&gt;
+        </li>
+<li class="listitem">
+          Use BOOST_CPP_XXX_HDR in order to include the header file for that library,
+          ie. #include BOOST_CPP_XXX_HDR
+        </li>
+<li class="listitem">
+          Use the macro BOOST_CPP_XXX_NS as the namespace for that library when using
+          the functionality of that library, ie. BOOST_CPP_XXX_NS::some_library_functionality
+        </li>
+<li class="listitem">
+          If necessary use the macro BOOST_CPP_HAS_XXX to determine whether the C++
+          standard version of the library is available or not. If BOOST_CPP_HAS_XXX
+          is 1 the C++ standard version of the library is available for use and if
+          BOOST_CPP_HAS_XXX is 0 only the Boost version of the library is available
+          for use, ie. #if BOOST_CPP_HAS_XXX for code that depends only on the C++
+          standard version of the library or #if !BOOST_CPP_HAS_XXX for code that
+          depends only on the Boost version of the library
+        </li>
+</ul></div>
+<p>
+      The following table lists the libraries and the appropriate information for
+      each one:
+    </p>
+<div class="table">
+<a name="boost_config.macros_that_choose_standard_or_boost_libraries.t0"></a><p class="title"><b>Table&#160;1.1.&#160;Libraries</b></p>
+<div class="table-contents"><table class="table" summary="Libraries">
+<colgroup>
+<col>
+<col>
+<col>
+<col>
+<col>
+</colgroup>
+<thead><tr>
+<th>
+              <p>
+                Library
+              </p>
+            </th>
+<th>
+              <p>
+                Header file
+              </p>
+            </th>
+<th>
+              <p>
+                Include macro
+              </p>
+            </th>
+<th>
+              <p>
+                Namespace macro
+              </p>
+            </th>
+<th>
+              <p>
+                Check C++ standard version macro
+              </p>
+            </th>
+</tr></thead>
+<tbody>
+<tr>
+<td>
+              <p>
+                array
+              </p>
+            </td>
+<td>
+              <p>
+                &lt;boost/config/cpp/array.hpp&gt;
+              </p>
+            </td>
+<td>
+              <p>
+                BOOST_CPP_ARRAY_HDR
+              </p>
+            </td>
+<td>
+              <p>
+                BOOST_CPP_ARRAY_NS
+              </p>
+            </td>
+<td>
+              <p>
+                BOOST_CPP_HAS_ARRAY
+              </p>
+            </td>
+</tr>
+<tr>
+<td>
+              <p>
+                atomic
+              </p>
+            </td>
+<td>
+              <p>
+                &lt;boost/config/cpp/atomic.hpp&gt;
+              </p>
+            </td>
+<td>
+              <p>
+                BOOST_CPP_ATOMIC_HDR
+              </p>
+            </td>
+<td>
+              <p>
+                BOOST_CPP_ATOMIC_NS
+              </p>
+            </td>
+<td>
+              <p>
+                BOOST_CPP_HAS_ATOMIC
+              </p>
+            </td>
+</tr>
+<tr>
+<td>
+              <p>
+                bind
+              </p>
+            </td>
+<td>
+              <p>
+                &lt;boost/config/cpp/bind.hpp&gt;
+              </p>
+            </td>
+<td>
+              <p>
+                BOOST_CPP_BIND_HDR
+              </p>
+            </td>
+<td>
+              <p>
+                BOOST_CPP_BIND_NS
+              </p>
+            </td>
+<td>
+              <p>
+                BOOST_CPP_HAS_BIND
+              </p>
+            </td>
+</tr>
+<tr>
+<td>
+              <p>
+                chrono
+              </p>
+            </td>
+<td>
+              <p>
+                &lt;boost/config/cpp/chrono.hpp&gt;
+              </p>
+            </td>
+<td>
+              <p>
+                BOOST_CPP_CHRONO_HDR
+              </p>
+            </td>
+<td>
+              <p>
+                BOOST_CPP_CHRONO_NS
+              </p>
+            </td>
+<td>
+              <p>
+                BOOST_CPP_HAS_CHRONO
+              </p>
+            </td>
+</tr>
+<tr>
+<td>
+              <p>
+                function
+              </p>
+            </td>
+<td>
+              <p>
+                &lt;boost/config/cpp/function.hpp&gt;
+              </p>
+            </td>
+<td>
+              <p>
+                BOOST_CPP_FUNCTION_HDR
+              </p>
+            </td>
+<td>
+              <p>
+                BOOST_CPP_FUNCTION_NS
+              </p>
+            </td>
+<td>
+              <p>
+                BOOST_CPP_HAS_FUNCTION
+              </p>
+            </td>
+</tr>
+<tr>
+<td>
+              <p>
+                hash
+              </p>
+            </td>
+<td>
+              <p>
+                &lt;boost/config/cpp/hash.hpp&gt;
+              </p>
+            </td>
+<td>
+              <p>
+                BOOST_CPP_HASH_HDR
+              </p>
+            </td>
+<td>
+              <p>
+                BOOST_CPP_HASH_NS
+              </p>
+            </td>
+<td>
+              <p>
+                BOOST_CPP_HAS_HASH
+              </p>
+            </td>
+</tr>
+<tr>
+<td>
+              <p>
+                mem_fn
+              </p>
+            </td>
+<td>
+              <p>
+                &lt;boost/config/cpp/mem_fn.hpp&gt;
+              </p>
+            </td>
+<td>
+              <p>
+                BOOST_CPP_MEM_FN_HDR
+              </p>
+            </td>
+<td>
+              <p>
+                BOOST_CPP_MEM_FN_NS
+              </p>
+            </td>
+<td>
+              <p>
+                BOOST_CPP_HAS_MEM_FN
+              </p>
+            </td>
+</tr>
+<tr>
+<td>
+              <p>
+                random
+              </p>
+            </td>
+<td>
+              <p>
+                &lt;boost/config/cpp/random.hpp&gt;
+              </p>
+            </td>
+<td>
+              <p>
+                BOOST_CPP_RANDOM_HDR
+              </p>
+            </td>
+<td>
+              <p>
+                BOOST_CPP_RANDOM_NS
+              </p>
+            </td>
+<td>
+              <p>
+                BOOST_CPP_HAS_RANDOM
+              </p>
+            </td>
+</tr>
+<tr>
+<td>
+              <p>
+                ratio
+              </p>
+            </td>
+<td>
+              <p>
+                &lt;boost/config/cpp/ratio.hpp&gt;
+              </p>
+            </td>
+<td>
+              <p>
+                BOOST_CPP_RATIO_HDR
+              </p>
+            </td>
+<td>
+              <p>
+                BOOST_CPP_RATIO_NS
+              </p>
+            </td>
+<td>
+              <p>
+                BOOST_CPP_HAS_RATIO
+              </p>
+            </td>
+</tr>
+<tr>
+<td>
+              <p>
+                ref
+              </p>
+            </td>
+<td>
+              <p>
+                &lt;boost/config/cpp/ref.hpp&gt;
+              </p>
+            </td>
+<td>
+              <p>
+                BOOST_CPP_REF_HDR
+              </p>
+            </td>
+<td>
+              <p>
+                BOOST_CPP_REF_NS
+              </p>
+            </td>
+<td>
+              <p>
+                BOOST_CPP_HAS_REF
+              </p>
+            </td>
+</tr>
+<tr>
+<td>
+              <p>
+                regex
+              </p>
+            </td>
+<td>
+              <p>
+                &lt;boost/config/cpp/regex.hpp&gt;
+              </p>
+            </td>
+<td>
+              <p>
+                BOOST_CPP_REGEX_HDR
+              </p>
+            </td>
+<td>
+              <p>
+                BOOST_CPP_REGEX_NS
+              </p>
+            </td>
+<td>
+              <p>
+                BOOST_CPP_HAS_REGEX
+              </p>
+            </td>
+</tr>
+<tr>
+<td>
+              <p>
+                shared_ptr
+              </p>
+            </td>
+<td>
+              <p>
+                &lt;boost/config/cpp/shared_ptr.hpp&gt;
+              </p>
+            </td>
+<td>
+              <p>
+                BOOST_CPP_SHARED_PTR_HDR
+              </p>
+            </td>
+<td>
+              <p>
+                BOOST_CPP_SHARED_PTR_NS
+              </p>
+            </td>
+<td>
+              <p>
+                BOOST_CPP_HAS_SHARED_PTR
+              </p>
+            </td>
+</tr>
+<tr>
+<td>
+              <p>
+                thread
+              </p>
+            </td>
+<td>
+              <p>
+                &lt;boost/config/cpp/thread.hpp&gt;
+              </p>
+            </td>
+<td>
+              <p>
+                BOOST_CPP_THREAD_HDR
+              </p>
+            </td>
+<td>
+              <p>
+                BOOST_CPP_THREAD_NS
+              </p>
+            </td>
+<td>
+              <p>
+                BOOST_CPP_HAS_THREAD
+              </p>
+            </td>
+</tr>
+<tr>
+<td>
+              <p>
+                tuple
+              </p>
+            </td>
+<td>
+              <p>
+                &lt;boost/config/cpp/tuple.hpp&gt;
+              </p>
+            </td>
+<td>
+              <p>
+                BOOST_CPP_TUPLE_HDR
+              </p>
+            </td>
+<td>
+              <p>
+                BOOST_CPP_TUPLE_NS
+              </p>
+            </td>
+<td>
+              <p>
+                BOOST_CPP_HAS_TUPLE
+              </p>
+            </td>
+</tr>
+<tr>
+<td>
+              <p>
+                type_index
+              </p>
+            </td>
+<td>
+              <p>
+                &lt;boost/config/cpp/type_index.hpp&gt;
+              </p>
+            </td>
+<td>
+              <p>
+                BOOST_CPP_TYPE_INDEX_HDR
+              </p>
+            </td>
+<td>
+              <p>
+                BOOST_CPP_TYPE_INDEX_NS
+              </p>
+            </td>
+<td>
+              <p>
+                BOOST_CPP_HAS_TYPE_INDEX
+              </p>
+            </td>
+</tr>
+<tr>
+<td>
+              <p>
+                type_traits
+              </p>
+            </td>
+<td>
+              <p>
+                &lt;boost/config/cpp/type_traits.hpp&gt;
+              </p>
+            </td>
+<td>
+              <p>
+                BOOST_CPP_TYPE_TRAITS_HDR
+              </p>
+            </td>
+<td>
+              <p>
+                BOOST_CPP_TYPE_TRAITS_NS
+              </p>
+            </td>
+<td>
+              <p>
+                BOOST_CPP_HAS_TYPE_TRAITS
+              </p>
+            </td>
+</tr>
+<tr>
+<td>
+              <p>
+                unordered_map
+              </p>
+            </td>
+<td>
+              <p>
+                &lt;boost/config/cpp/unordered_map.hpp&gt;
+              </p>
+            </td>
+<td>
+              <p>
+                BOOST_CPP_UNORDERED_MAP_HDR
+              </p>
+            </td>
+<td>
+              <p>
+                BOOST_CPP_UNORDERED_MAP_NS
+              </p>
+            </td>
+<td>
+              <p>
+                BOOST_CPP_HAS_UNORDERED_MAP
+              </p>
+            </td>
+</tr>
+<tr>
+<td>
+              <p>
+                unordered_multimap
+              </p>
+            </td>
+<td>
+              <p>
+                &lt;boost/config/cpp/unordered_multimap.hpp&gt;
+              </p>
+            </td>
+<td>
+              <p>
+                BOOST_CPP_UNORDERED_MULTIMAP_HDR
+              </p>
+            </td>
+<td>
+              <p>
+                BOOST_CPP_UNORDERED_MULTIMAP_NS
+              </p>
+            </td>
+<td>
+              <p>
+                BOOST_CPP_HAS_UNORDERED_MULTIMAP
+              </p>
+            </td>
+</tr>
+<tr>
+<td>
+              <p>
+                unordered_multiset
+              </p>
+            </td>
+<td>
+              <p>
+                &lt;boost/config/cpp/unordered_multiset.hpp&gt;
+              </p>
+            </td>
+<td>
+              <p>
+                BOOST_CPP_UNORDERED_MULTISET_HDR
+              </p>
+            </td>
+<td>
+              <p>
+                BOOST_CPP_UNORDERED_MULTISET_NS
+              </p>
+            </td>
+<td>
+              <p>
+                BOOST_CPP_HAS_UNORDERED_MULTISET
+              </p>
+            </td>
+</tr>
+<tr>
+<td>
+              <p>
+                unordered_set
+              </p>
+            </td>
+<td>
+              <p>
+                &lt;boost/config/cpp/unordered_set.hpp&gt;
+              </p>
+            </td>
+<td>
+              <p>
+                BOOST_CPP_UNORDERED_SET_HDR
+              </p>
+            </td>
+<td>
+              <p>
+                BOOST_CPP_UNORDERED_SET_NS
+              </p>
+            </td>
+<td>
+              <p>
+                BOOST_CPP_HAS_UNORDERED_SET
+              </p>
+            </td>
+</tr>
+</tbody>
+</table></div>
+</div>
+<br class="table-break"><h4>
+<a name="boost_config.macros_that_choose_standard_or_boost_libraries.h0"></a>
+      <span class="phrase"><a name="boost_config.macros_that_choose_standard_or_boost_libraries.using_the_macros_"></a></span><a class="link" href="macros_that_choose_standard_or_boost_libraries.html#boost_config.macros_that_choose_standard_or_boost_libraries.using_the_macros_">Using
+      the macros </a>
+    </h4>
+<p>
+      The general form of using these macros in a translation unit will now be given,
+      choosing the regex library as an example.
+    </p>
+<pre class="programlisting"><span class="preprocessor">#include</span> <span class="special">&lt;</span><span class="identifier">boost</span><span class="special">/</span><span class="identifier">config</span><span class="special">/</span><span class="identifier">cpp</span><span class="special">/</span><span class="identifier">regex</span><span class="special">.</span><span class="identifier">hpp</span><span class="special">&gt;</span>
+<span class="preprocessor">#include</span> <span class="identifier">BOOST_CPP_REGEX_HDR</span>
+
+<span class="keyword">void</span> <span class="identifier">SomeFunction</span><span class="special">()</span>
+  <span class="special">{</span>
+  <span class="identifier">BOOST_CPP_REGEX_NS</span><span class="special">::</span><span class="identifier">regex</span> <span class="identifier">re</span><span class="special">(</span><span class="string">"A regular expression etc."</span><span class="special">);</span>
+  <span class="keyword">bool</span> <span class="identifier">result</span><span class="special">(</span><span class="identifier">BOOST_CPP_REGEX_NS</span><span class="special">::</span><span class="identifier">regex_match</span><span class="special">(</span><span class="string">"Some string..."</span><span class="special">,</span><span class="identifier">re</span><span class="special">));</span>
+  <span class="comment">// etc.</span>
+  <span class="special">}</span>
+</pre>
+<p>
+      In the example the code will work whether we are using the C++ standard regex
+      library or the Boost regex library.
+    </p>
+<h4>
+<a name="boost_config.macros_that_choose_standard_or_boost_libraries.h1"></a>
+      <span class="phrase"><a name="boost_config.macros_that_choose_standard_or_boost_libraries.using_the_boost_cpp_has_____macro_"></a></span><a class="link" href="macros_that_choose_standard_or_boost_libraries.html#boost_config.macros_that_choose_standard_or_boost_libraries.using_the_boost_cpp_has_____macro_">Using
+      the BOOST_CPP_HAS_... macro </a>
+    </h4>
+<p>
+      The BOOST_CPP_HAS_ macro for any given library is a more understandable form
+      of macro than Boost.config already has for determining whether the compiler
+      supports certain C++ libraries. Most of these macros are taken from whether
+      or not a given BOOST_NO_CXX11_HDR_ is defined. You can use a BOOST_CPP_HAS_
+      macro to discover whether a Boost library is also supported by an equivalent
+      C++ standard library. You may decide you need the C++ standard version of a
+      particular library, rather than the Boost version, or else you do not want
+      your code to compile. As an example let's say that you want to create a compile
+      error if the compiler does not support the C++ standard library type_traits
+      library, even though the Boost type_traits library could also normally be used.
+    </p>
+<pre class="programlisting"><span class="preprocessor">#include</span> <span class="special">&lt;</span><span class="identifier">boost</span><span class="special">/</span><span class="identifier">config</span><span class="special">/</span><span class="identifier">cpp</span><span class="special">/</span><span class="identifier">type_traits</span><span class="special">.</span><span class="identifier">hpp</span><span class="special">&gt;</span>
+<span class="preprocessor">#if</span> <span class="special">!</span><span class="identifier">BOOST_CPP_HAS_TYPE_TRAITS</span>
+<span class="preprocessor">#error</span> <span class="identifier">C</span><span class="special">++</span> <span class="identifier">standard</span> <span class="identifier">type_traits</span> <span class="identifier">library</span> <span class="identifier">needed</span> <span class="keyword">and</span> <span class="keyword">not</span> <span class="identifier">present</span><span class="special">.</span>
+<span class="preprocessor">#endif</span>
+
+<span class="comment">// Further code</span>
+</pre>
+<p>
+      Another use for the BOOST_CPP_HAS_ macro is to include particular header files
+      rather than a main header file, for some given library functionality. This
+      is more prevalent with Boost than with the C++ standard library, the latter
+      almost always having a single header file which includes library functionality
+      for all parts of a library.
+    </p>
+<pre class="programlisting"><span class="preprocessor">#include</span> <span class="special">&lt;</span><span class="identifier">boost</span><span class="special">/</span><span class="identifier">config</span><span class="special">/</span><span class="identifier">cpp</span><span class="special">/</span><span class="identifier">type_traits</span><span class="special">.</span><span class="identifier">hpp</span><span class="special">&gt;</span>
+<span class="preprocessor">#if</span> <span class="identifier">BOOST_CPP_HAS_TYPE_TRAITS</span>
+<span class="preprocessor">#include</span> <span class="identifier">BOOST_CPP_TYPE_TRAITS_HDR</span>
+<span class="preprocessor">#else</span>
+<span class="preprocessor">#include</span> <span class="special">&lt;</span><span class="identifier">boost</span><span class="special">/</span><span class="identifier">type_traits</span><span class="special">/</span><span class="identifier">add_const</span><span class="special">.</span><span class="identifier">hpp</span><span class="special">&gt;</span>
+<span class="preprocessor">#endif</span>
+
+<span class="comment">// Further code using BOOST_CPP_TYPE_TRAITS_NS::add_const</span>
+</pre>
+<p>
+      You can also use the BOOST_CPP_HAS_ macro to provide specific functionality
+      depending on whether or not a particular library is using the C++ standard
+      or Boost version. Of course you hope to minimize these situations but occasionally
+      they happen:
+    </p>
+<pre class="programlisting"><span class="preprocessor">#include</span> <span class="special">&lt;</span><span class="identifier">boost</span><span class="special">/</span><span class="identifier">config</span><span class="special">/</span><span class="identifier">cpp</span><span class="special">/</span><span class="identifier">thread</span><span class="special">.</span><span class="identifier">hpp</span><span class="special">&gt;</span>
+<span class="preprocessor">#include</span> <span class="identifier">BOOST_CPP_THREAD_HDR</span>
+
+<span class="comment">// Code...</span>
+
+<span class="preprocessor">#if</span> <span class="identifier">BOOST_CPP_HAS_THREAD</span>
+
+<span class="comment">// Functionality available if the C++ standard version of the thread library is being used</span>
+
+<span class="preprocessor">#else</span>
+
+<span class="comment">// Functionality available if the Boost version of the thread library is being used</span>
+
+<span class="preprocessor">#endif</span>
+</pre>
+<h4>
+<a name="boost_config.macros_that_choose_standard_or_boost_libraries.h2"></a>
+      <span class="phrase"><a name="boost_config.macros_that_choose_standard_or_boost_libraries.library_header_file_dependency_"></a></span><a class="link" href="macros_that_choose_standard_or_boost_libraries.html#boost_config.macros_that_choose_standard_or_boost_libraries.library_header_file_dependency_">Library
+      header file dependency </a>
+    </h4>
+<p>
+      When the programmer includes the appropriate header file for a particular library
+      from within the boost/config/cpp subdirectory there is no dependency being
+      established on the library itself. Any one of the library header files merely
+      defines macros which the programmer may choose to use or not.
+    </p>
+<p>
+      It is only when using a particular include macro, along with a particular namespace
+      macro, from any given library that a dependency is established.
+    </p>
+<p>
+      Because of this it has been made possible to include all library headers with
+      a single include:
+    </p>
+<pre class="programlisting"><span class="preprocessor">#include</span> <span class="special">&lt;</span><span class="identifier">boost</span><span class="special">/</span><span class="identifier">config</span><span class="special">/</span><span class="identifier">cpp</span><span class="special">.</span><span class="identifier">h</span><span class="special">&gt;</span>
+</pre>
+<p>
+      This includes macros for each library, starting with BOOST_CPP_, but as long
+      as the prefix BOOST_CPP_ does not conflict with macros from any other software
+      library in the translation unit there should be no problems.
+    </p>
+</div>
+<table xmlns:rev="http://www.cs.rpi.edu/~gregod/boost/tools/doc/revision" width="100%"><tr>
+<td align="left"></td>
+<td align="right"><div class="copyright-footer">Copyright &#169; 2001-2007 Beman Dawes, Vesa Karvonen, John
+      Maddock<p>
+        Distributed under the Boost Software License, Version 1.0. (See accompanying
+        file LICENSE_1_0.txt or copy at <a href="http://www.boost.org/LICENSE_1_0.txt" target="_top">http://www.boost.org/LICENSE_1_0.txt</a>)
+      </p>
+</div></td>
+</tr></table>
+<hr>
+<div class="spirit-nav">
+<a accesskey="p" href="acknowledgements.html"><img src="../../../../../doc/src/images/prev.png" alt="Prev"></a><a accesskey="u" href="../index.html"><img src="../../../../../doc/src/images/up.png" alt="Up"></a><a accesskey="h" href="../index.html"><img src="../../../../../doc/src/images/home.png" alt="Home"></a>
+</div>
+</body>
+</html>

--- a/doc/html/boost_config/rationale.html
+++ b/doc/html/boost_config/rationale.html
@@ -4,8 +4,8 @@
 <title>Rationale</title>
 <link rel="stylesheet" href="../../../../../doc/src/boostbook.css" type="text/css">
 <meta name="generator" content="DocBook XSL Stylesheets V1.78.1">
-<link rel="home" href="../index.html" title="Boost.Config">
-<link rel="up" href="../index.html" title="Boost.Config">
+<link rel="home" href="../index.html" title="Chapter&#160;1.&#160;Boost.Config">
+<link rel="up" href="../index.html" title="Chapter&#160;1.&#160;Boost.Config">
 <link rel="prev" href="guidelines_for_boost_authors.html" title="Guidelines for Boost Authors">
 <link rel="next" href="acknowledgements.html" title="Acknowledgements">
 </head>

--- a/doc/html/index.html
+++ b/doc/html/index.html
@@ -987,7 +987,7 @@
 </div>
 </div>
 <table xmlns:rev="http://www.cs.rpi.edu/~gregod/boost/tools/doc/revision" width="100%"><tr>
-<td align="left"><p><small>Last revised: May 28, 2015 at 16:50:58 GMT</small></p></td>
+<td align="left"><p><small>Last revised: May 28, 2015 at 18:36:25 GMT</small></p></td>
 <td align="right"><div class="copyright-footer"></div></td>
 </tr></table>
 <hr>

--- a/doc/html/index.html
+++ b/doc/html/index.html
@@ -1,10 +1,10 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=US-ASCII">
-<title>Boost.Config</title>
+<title>Chapter&#160;1.&#160;Boost.Config</title>
 <link rel="stylesheet" href="../../../../doc/src/boostbook.css" type="text/css">
 <meta name="generator" content="DocBook XSL Stylesheets V1.78.1">
-<link rel="home" href="index.html" title="Boost.Config">
+<link rel="home" href="index.html" title="Chapter&#160;1.&#160;Boost.Config">
 <link rel="next" href="boost_config/boost_macro_reference.html" title="Boost Macro Reference">
 </head>
 <body bgcolor="white" text="black" link="#0000FF" vlink="#840084" alink="#0000FF">
@@ -18,14 +18,13 @@
 </tr></table>
 <hr>
 <div class="spirit-nav"><a accesskey="n" href="boost_config/boost_macro_reference.html"><img src="../../../../doc/src/images/next.png" alt="Next"></a></div>
-<div class="article">
-<div class="titlepage">
-<div>
+<div class="chapter">
+<div class="titlepage"><div>
 <div><h2 class="title">
-<a name="config"></a>Boost.Config</h2></div>
-<div><div class="authorgroup"><div class="author"><h3 class="author">
+<a name="config"></a>Chapter&#160;1.&#160;Boost.Config</h2></div>
+<div><div class="author"><h3 class="author">
 <span class="firstname">Vesa Karvonen, John Maddock</span> <span class="surname">Beman Dawes</span>
-</h3></div></div></div>
+</h3></div></div>
 <div><p class="copyright">Copyright &#169; 2001-2007 Beman Dawes, Vesa Karvonen, John
       Maddock</p></div>
 <div><div class="legalnotice">
@@ -34,9 +33,7 @@
         file LICENSE_1_0.txt or copy at <a href="http://www.boost.org/LICENSE_1_0.txt" target="_top">http://www.boost.org/LICENSE_1_0.txt</a>)
       </p>
 </div></div>
-</div>
-<hr>
-</div>
+</div></div>
 <div class="toc">
 <p><b>Table of Contents</b></p>
 <dl class="toc">
@@ -72,6 +69,8 @@
       that describe C++14 features not supported</a></span></dt>
 <dt><span class="section"><a href="boost_config/boost_macro_reference.html#boost_config.boost_macro_reference.macros_that_allow_use_of_c__14_features_with_c__11_or_earlier_compilers">Macros
       that allow use of C++14 features with C++11 or earlier compilers</a></span></dt>
+<dt><span class="section"><a href="boost_config/boost_macro_reference.html#boost_config.boost_macro_reference.macros_that_choose_standard_or_boost_libraries">Macros
+      that choose standard or Boost libraries</a></span></dt>
 <dt><span class="section"><a href="boost_config/boost_macro_reference.html#boost_config.boost_macro_reference.boost_helper_macros">Boost
       Helper Macros</a></span></dt>
 <dt><span class="section"><a href="boost_config/boost_macro_reference.html#boost_config.boost_macro_reference.boost_informational_macros">Boost
@@ -988,7 +987,7 @@
 </div>
 </div>
 <table xmlns:rev="http://www.cs.rpi.edu/~gregod/boost/tools/doc/revision" width="100%"><tr>
-<td align="left"><p><small>Last revised: May 04, 2015 at 13:34:36 GMT</small></p></td>
+<td align="left"><p><small>Last revised: May 28, 2015 at 16:50:58 GMT</small></p></td>
 <td align="right"><div class="copyright-footer"></div></td>
 </tr></table>
 <hr>

--- a/doc/macro_reference.qbk
+++ b/doc/macro_reference.qbk
@@ -918,6 +918,8 @@ provide compliant C++14 support.
 
 [endsect]
 
+[include choosing.qbk]
+
 [#config_helpers]
 
 [section Boost Helper Macros]

--- a/include/boost/config/cpp.hpp
+++ b/include/boost/config/cpp.hpp
@@ -1,0 +1,32 @@
+//  boost/config/cpp.hpp  ---------------------------------------------------//
+
+//  (C) Copyright Edward Diener 2015. 
+//  Use, modification and distribution are subject to the 
+//  Boost Software License, Version 1.0. (See accompanying file 
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(BOOST_CONFIG_CPP_HPP)
+#define BOOST_CONFIG_CPP_HPP
+
+#include <boost/cpp/array.hpp>
+#include <boost/cpp/atomic.hpp>
+#include <boost/cpp/bind.hpp>
+#include <boost/cpp/chrono.hpp>
+#include <boost/cpp/function.hpp>
+#include <boost/cpp/hash.hpp>
+#include <boost/cpp/mem_fn.hpp>
+#include <boost/cpp/random.hpp>
+#include <boost/cpp/ratio.hpp>
+#include <boost/cpp/ref.hpp>
+#include <boost/cpp/regex.hpp>
+#include <boost/cpp/shared_ptr.hpp>
+#include <boost/cpp/thread.hpp>
+#include <boost/cpp/tuple.hpp>
+#include <boost/cpp/type_index.hpp>
+#include <boost/cpp/type_traits.hpp>
+#include <boost/cpp/unordered_map.hpp>
+#include <boost/cpp/unordered_multimap.hpp>
+#include <boost/cpp/unordered_multiset.hpp>
+#include <boost/cpp/unordered_set.hpp>
+
+#endif // !defined(BOOST_CONFIG_CPP_HPP)

--- a/include/boost/config/cpp.hpp
+++ b/include/boost/config/cpp.hpp
@@ -8,25 +8,25 @@
 #if !defined(BOOST_CONFIG_CPP_HPP)
 #define BOOST_CONFIG_CPP_HPP
 
-#include <boost/cpp/array.hpp>
-#include <boost/cpp/atomic.hpp>
-#include <boost/cpp/bind.hpp>
-#include <boost/cpp/chrono.hpp>
-#include <boost/cpp/function.hpp>
-#include <boost/cpp/hash.hpp>
-#include <boost/cpp/mem_fn.hpp>
-#include <boost/cpp/random.hpp>
-#include <boost/cpp/ratio.hpp>
-#include <boost/cpp/ref.hpp>
-#include <boost/cpp/regex.hpp>
-#include <boost/cpp/shared_ptr.hpp>
-#include <boost/cpp/thread.hpp>
-#include <boost/cpp/tuple.hpp>
-#include <boost/cpp/type_index.hpp>
-#include <boost/cpp/type_traits.hpp>
-#include <boost/cpp/unordered_map.hpp>
-#include <boost/cpp/unordered_multimap.hpp>
-#include <boost/cpp/unordered_multiset.hpp>
-#include <boost/cpp/unordered_set.hpp>
+#include <boost/config/cpp/array.hpp>
+#include <boost/config/cpp/atomic.hpp>
+#include <boost/config/cpp/bind.hpp>
+#include <boost/config/cpp/chrono.hpp>
+#include <boost/config/cpp/function.hpp>
+#include <boost/config/cpp/hash.hpp>
+#include <boost/config/cpp/mem_fn.hpp>
+#include <boost/config/cpp/random.hpp>
+#include <boost/config/cpp/ratio.hpp>
+#include <boost/config/cpp/ref.hpp>
+#include <boost/config/cpp/regex.hpp>
+#include <boost/config/cpp/shared_ptr.hpp>
+#include <boost/config/cpp/thread.hpp>
+#include <boost/config/cpp/tuple.hpp>
+#include <boost/config/cpp/type_index.hpp>
+#include <boost/config/cpp/type_traits.hpp>
+#include <boost/config/cpp/unordered_map.hpp>
+#include <boost/config/cpp/unordered_multimap.hpp>
+#include <boost/config/cpp/unordered_multiset.hpp>
+#include <boost/config/cpp/unordered_set.hpp>
 
 #endif // !defined(BOOST_CONFIG_CPP_HPP)

--- a/include/boost/config/cpp/array.hpp
+++ b/include/boost/config/cpp/array.hpp
@@ -1,0 +1,22 @@
+//  boost/config/cpp/array.hpp  ---------------------------------------------------//
+
+//  (C) Copyright Edward Diener 2015. 
+//  Use, modification and distribution are subject to the 
+//  Boost Software License, Version 1.0. (See accompanying file 
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(BOOST_CONFIG_CPP_ARRAY_HPP)
+#define BOOST_CONFIG_CPP_ARRAY_HPP
+
+#include <boost/config.hpp>
+#if defined(BOOST_NO_CXX11_HDR_ARRAY)
+#define BOOST_CPP_HAS_ARRAY 0
+#define BOOST_CPP_ARRAY_NS boost
+#define BOOST_CPP_ARRAY_HDR <boost/array.hpp>
+#else
+#define BOOST_CPP_HAS_ARRAY 1
+#define BOOST_CPP_ARRAY_NS std
+#define BOOST_CPP_ARRAY_HDR <array>
+#endif
+
+#endif // !defined(BOOST_CONFIG_CPP_ARRAY_HPP)

--- a/include/boost/config/cpp/atomic.hpp
+++ b/include/boost/config/cpp/atomic.hpp
@@ -1,0 +1,24 @@
+//  boost/config/cpp/atomic.hpp  ---------------------------------------------------//
+
+//  (C) Copyright Edward Diener 2015. 
+//  Use, modification and distribution are subject to the 
+//  Boost Software License, Version 1.0. (See accompanying file 
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(BOOST_CONFIG_CPP_ATOMIC_HPP)
+#define BOOST_CONFIG_CPP_ATOMIC_HPP
+
+#include <boost/config.hpp>
+#if defined(BOOST_NO_CXX11_HDR_ATOMIC)
+#define BOOST_CPP_HAS_ATOMIC 0
+#define BOOST_CPP_ATOMIC_NS boost
+#define BOOST_CPP_ATOMIC_HDR <boost/atomic/atomic.hpp>
+#define BOOST_CPP_ATOMIC_MACRO(macro) BOOST_ ## macro
+#else
+#define BOOST_CPP_HAS_ATOMIC 1
+#define BOOST_CPP_ATOMIC_NS std
+#define BOOST_CPP_ATOMIC_HDR <atomic>
+#define BOOST_CPP_ATOMIC_MACRO(macro) macro
+#endif
+
+#endif // !defined(BOOST_CONFIG_CPP_ATOMIC_HPP)

--- a/include/boost/config/cpp/bind.hpp
+++ b/include/boost/config/cpp/bind.hpp
@@ -1,0 +1,22 @@
+//  boost/config/cpp/bind.hpp  ---------------------------------------------------//
+
+//  (C) Copyright Edward Diener 2015. 
+//  Use, modification and distribution are subject to the 
+//  Boost Software License, Version 1.0. (See accompanying file 
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(BOOST_CONFIG_CPP_BIND_HPP)
+#define BOOST_CONFIG_CPP_BIND_HPP
+
+#include <boost/config.hpp>
+#if defined(BOOST_NO_CXX11_HDR_FUNCTIONAL)
+#define BOOST_CPP_HAS_BIND 0
+#define BOOST_CPP_BIND_NS boost
+#define BOOST_CPP_BIND_HDR <boost/bind/bind.hpp>
+#else
+#define BOOST_CPP_HAS_BIND 1
+#define BOOST_CPP_BIND_NS std
+#define BOOST_CPP_BIND_HDR <functional>
+#endif
+
+#endif // !defined(BOOST_CONFIG_CPP_BIND_HPP)

--- a/include/boost/config/cpp/chrono.hpp
+++ b/include/boost/config/cpp/chrono.hpp
@@ -1,0 +1,22 @@
+//  boost/config/cpp/chrono.hpp  ---------------------------------------------------//
+
+//  (C) Copyright Edward Diener 2015. 
+//  Use, modification and distribution are subject to the 
+//  Boost Software License, Version 1.0. (See accompanying file 
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(BOOST_CONFIG_CPP_CHRONO_HPP)
+#define BOOST_CONFIG_CPP_CHRONO_HPP
+
+#include <boost/config.hpp>
+#if defined(BOOST_NO_CXX11_HDR_CHRONO)
+#define BOOST_CPP_HAS_CHRONO 0
+#define BOOST_CPP_CHRONO_NS boost
+#define BOOST_CPP_CHRONO_HDR <boost/chrono.hpp>
+#else
+#define BOOST_CPP_HAS_CHRONO 1
+#define BOOST_CPP_CHRONO_NS std
+#define BOOST_CPP_CHRONO_HDR <chrono>
+#endif
+
+#endif // !defined(BOOST_CONFIG_CPP_CHRONO_HPP)

--- a/include/boost/config/cpp/function.hpp
+++ b/include/boost/config/cpp/function.hpp
@@ -1,0 +1,22 @@
+//  boost/config/cpp/function.hpp  ---------------------------------------------------//
+
+//  (C) Copyright Edward Diener 2015. 
+//  Use, modification and distribution are subject to the 
+//  Boost Software License, Version 1.0. (See accompanying file 
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(BOOST_CONFIG_CPP_FUNCTION_HPP)
+#define BOOST_CONFIG_CPP_FUNCTION_HPP
+
+#include <boost/config.hpp>
+#if defined(BOOST_NO_CXX11_HDR_FUNCTIONAL)
+#define BOOST_CPP_HAS_FUNCTION 0
+#define BOOST_CPP_FUNCTION_NS boost
+#define BOOST_CPP_FUNCTION_HDR <boost/function.hpp>
+#else
+#define BOOST_CPP_HAS_FUNCTION 1
+#define BOOST_CPP_FUNCTION_NS std
+#define BOOST_CPP_FUNCTION_HDR <functional>
+#endif
+
+#endif // !defined(BOOST_CONFIG_CPP_FUNCTION_HPP)

--- a/include/boost/config/cpp/hash.hpp
+++ b/include/boost/config/cpp/hash.hpp
@@ -1,0 +1,22 @@
+//  boost/config/cpp/hash.hpp  ---------------------------------------------------//
+
+//  (C) Copyright Edward Diener 2015. 
+//  Use, modification and distribution are subject to the 
+//  Boost Software License, Version 1.0. (See accompanying file 
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(BOOST_CONFIG_CPP_HASH_HPP)
+#define BOOST_CONFIG_CPP_HASH_HPP
+
+#include <boost/config.hpp>
+#if defined(BOOST_NO_CXX11_HDR_FUNCTIONAL)
+#define BOOST_CPP_HAS_HASH 0
+#define BOOST_CPP_HASH_NS boost
+#define BOOST_CPP_HASH_HDR <boost/functional/hash.hpp>
+#else
+#define BOOST_CPP_HAS_HASH 1
+#define BOOST_CPP_HASH_NS std
+#define BOOST_CPP_HASH_HDR <functional>
+#endif
+
+#endif // !defined(BOOST_CONFIG_CPP_HASH_HPP)

--- a/include/boost/config/cpp/mem_fn.hpp
+++ b/include/boost/config/cpp/mem_fn.hpp
@@ -1,0 +1,22 @@
+//  boost/config/cpp/mem_fn.hpp  ---------------------------------------------------//
+
+//  (C) Copyright Edward Diener 2015. 
+//  Use, modification and distribution are subject to the 
+//  Boost Software License, Version 1.0. (See accompanying file 
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(BOOST_CONFIG_CPP_MEM_FN_HPP)
+#define BOOST_CONFIG_CPP_MEM_FN_HPP
+
+#include <boost/config.hpp>
+#if defined(BOOST_NO_CXX11_HDR_FUNCTIONAL)
+#define BOOST_CPP_HAS_MEM_FN 0
+#define BOOST_CPP_MEM_FN_NS boost
+#define BOOST_CPP_MEM_FN_HDR <boost/mem_fn.hpp>
+#else
+#define BOOST_CPP_HAS_MEM_FN 1
+#define BOOST_CPP_MEM_FN_NS std
+#define BOOST_CPP_MEM_FN_HDR <functional>
+#endif
+
+#endif // !defined(BOOST_CONFIG_CPP_MEM_FN_HPP)

--- a/include/boost/config/cpp/random.hpp
+++ b/include/boost/config/cpp/random.hpp
@@ -1,0 +1,22 @@
+//  boost/config/cpp/random.hpp  ---------------------------------------------------//
+
+//  (C) Copyright Edward Diener 2015. 
+//  Use, modification and distribution are subject to the 
+//  Boost Software License, Version 1.0. (See accompanying file 
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(BOOST_CONFIG_CPP_RANDOM_HPP)
+#define BOOST_CONFIG_CPP_RANDOM_HPP
+
+#include <boost/config.hpp>
+#if defined(BOOST_NO_CXX11_HDR_RANDOM)
+#define BOOST_CPP_HAS_RANDOM 0
+#define BOOST_CPP_RANDOM_NS boost
+#define BOOST_CPP_RANDOM_HDR <boost/random.hpp>
+#else
+#define BOOST_CPP_HAS_RANDOM 1
+#define BOOST_CPP_RANDOM_NS std
+#define BOOST_CPP_RANDOM_HDR <random>
+#endif
+
+#endif // !defined(BOOST_CONFIG_CPP_RANDOM_HPP)

--- a/include/boost/config/cpp/random.hpp
+++ b/include/boost/config/cpp/random.hpp
@@ -11,7 +11,7 @@
 #include <boost/config.hpp>
 #if defined(BOOST_NO_CXX11_HDR_RANDOM)
 #define BOOST_CPP_HAS_RANDOM 0
-#define BOOST_CPP_RANDOM_NS boost
+#define BOOST_CPP_RANDOM_NS boost::random
 #define BOOST_CPP_RANDOM_HDR <boost/random.hpp>
 #else
 #define BOOST_CPP_HAS_RANDOM 1

--- a/include/boost/config/cpp/ratio.hpp
+++ b/include/boost/config/cpp/ratio.hpp
@@ -1,0 +1,22 @@
+//  boost/config/cpp/ratio.hpp  ---------------------------------------------------//
+
+//  (C) Copyright Edward Diener 2015. 
+//  Use, modification and distribution are subject to the 
+//  Boost Software License, Version 1.0. (See accompanying file 
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(BOOST_CONFIG_CPP_RATIO_HPP)
+#define BOOST_CONFIG_CPP_RATIO_HPP
+
+#include <boost/config.hpp>
+#if defined(BOOST_NO_CXX11_HDR_RATIO)
+#define BOOST_CPP_HAS_RATIO 0
+#define BOOST_CPP_RATIO_NS boost
+#define BOOST_CPP_RATIO_HDR <boost/ratio.hpp>
+#else
+#define BOOST_CPP_HAS_RATIO 1
+#define BOOST_CPP_RATIO_NS std
+#define BOOST_CPP_RATIO_HDR <ratio>
+#endif
+
+#endif // !defined(BOOST_CONFIG_CPP_RATIO_HPP)

--- a/include/boost/config/cpp/ref.hpp
+++ b/include/boost/config/cpp/ref.hpp
@@ -1,0 +1,22 @@
+//  boost/config/cpp/ref.hpp  ---------------------------------------------------//
+
+//  (C) Copyright Edward Diener 2015. 
+//  Use, modification and distribution are subject to the 
+//  Boost Software License, Version 1.0. (See accompanying file 
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(BOOST_CONFIG_CPP_REF_HPP)
+#define BOOST_CONFIG_CPP_REF_HPP
+
+#include <boost/config.hpp>
+#if defined(BOOST_NO_CXX11_HDR_FUNCTIONAL)
+#define BOOST_CPP_HAS_REF 0
+#define BOOST_CPP_REF_NS boost
+#define BOOST_CPP_REF_HDR <boost/core/ref.hpp>
+#else
+#define BOOST_CPP_HAS_REF 1
+#define BOOST_CPP_REF_NS std
+#define BOOST_CPP_REF_HDR <functional>
+#endif
+
+#endif // !defined(BOOST_CONFIG_CPP_REF_HPP)

--- a/include/boost/config/cpp/regex.hpp
+++ b/include/boost/config/cpp/regex.hpp
@@ -1,0 +1,22 @@
+//  boost/config/cpp/regex.hpp  ---------------------------------------------------//
+
+//  (C) Copyright Edward Diener 2015. 
+//  Use, modification and distribution are subject to the 
+//  Boost Software License, Version 1.0. (See accompanying file 
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(BOOST_CONFIG_CPP_REGEX_HPP)
+#define BOOST_CONFIG_CPP_REGEX_HPP
+
+#include <boost/config.hpp>
+#if defined(BOOST_NO_CXX11_HDR_REGEX)
+#define BOOST_CPP_HAS_REGEX 0
+#define BOOST_CPP_REGEX_NS boost
+#define BOOST_CPP_REGEX_HDR <boost/regex.hpp>
+#else
+#define BOOST_CPP_HAS_REGEX 1
+#define BOOST_CPP_REGEX_NS std
+#define BOOST_CPP_REGEX_HDR <regex>
+#endif
+
+#endif // !defined(BOOST_CONFIG_CPP_REGEX_HPP)

--- a/include/boost/config/cpp/shared_ptr.hpp
+++ b/include/boost/config/cpp/shared_ptr.hpp
@@ -1,0 +1,22 @@
+//  boost/config/cpp/shared_ptr.hpp  ---------------------------------------------------//
+
+//  (C) Copyright Edward Diener 2015. 
+//  Use, modification and distribution are subject to the 
+//  Boost Software License, Version 1.0. (See accompanying file 
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(BOOST_CONFIG_CPP_SHARED_PTR_HPP)
+#define BOOST_CONFIG_CPP_SHARED_PTR_HPP
+
+#include <boost/config.hpp>
+#if defined(BOOST_NO_CXX11_SMART_PTR)
+#define BOOST_CPP_HAS_SHARED_PTR 0
+#define BOOST_CPP_SHARED_PTR_NS boost
+#define BOOST_CPP_SHARED_PTR_HDR <boost/shared_ptr.hpp>
+#else
+#define BOOST_CPP_HAS_SHARED_PTR 1
+#define BOOST_CPP_SHARED_PTR_NS std
+#define BOOST_CPP_SHARED_PTR_HDR <memory>
+#endif
+
+#endif // !defined(BOOST_CONFIG_CPP_SHARED_PTR_HPP)

--- a/include/boost/config/cpp/thread.hpp
+++ b/include/boost/config/cpp/thread.hpp
@@ -1,0 +1,22 @@
+//  boost/config/cpp/thread.hpp  ---------------------------------------------------//
+
+//  (C) Copyright Edward Diener 2015. 
+//  Use, modification and distribution are subject to the 
+//  Boost Software License, Version 1.0. (See accompanying file 
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(BOOST_CONFIG_CPP_THREAD_HPP)
+#define BOOST_CONFIG_CPP_THREAD_HPP
+
+#include <boost/config.hpp>
+#if defined(BOOST_NO_CXX11_HDR_THREAD)
+#define BOOST_CPP_HAS_THREAD 0
+#define BOOST_CPP_THREAD_NS boost
+#define BOOST_CPP_THREAD_HDR <boost/thread/thread.hpp>
+#else
+#define BOOST_CPP_HAS_THREAD 1
+#define BOOST_CPP_THREAD_NS std
+#define BOOST_CPP_THREAD_HDR <thread>
+#endif
+
+#endif // !defined(BOOST_CONFIG_CPP_THREAD_HPP)

--- a/include/boost/config/cpp/tuple.hpp
+++ b/include/boost/config/cpp/tuple.hpp
@@ -1,0 +1,22 @@
+//  boost/config/cpp/tuple.hpp  ---------------------------------------------------//
+
+//  (C) Copyright Edward Diener 2015. 
+//  Use, modification and distribution are subject to the 
+//  Boost Software License, Version 1.0. (See accompanying file 
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(BOOST_CONFIG_CPP_TUPLE_HPP)
+#define BOOST_CONFIG_CPP_TUPLE_HPP
+
+#include <boost/config.hpp>
+#if defined(BOOST_NO_CXX11_HDR_TUPLE)
+#define BOOST_CPP_HAS_TUPLE 0
+#define BOOST_CPP_TUPLE_NS boost
+#define BOOST_CPP_TUPLE_HDR <boost/tuple/tuple.hpp>
+#else
+#define BOOST_CPP_HAS_TUPLE 1
+#define BOOST_CPP_TUPLE_NS std
+#define BOOST_CPP_TUPLE_HDR <tuple>
+#endif
+
+#endif // !defined(BOOST_CONFIG_CPP_TUPLE_HPP)

--- a/include/boost/config/cpp/type_index.hpp
+++ b/include/boost/config/cpp/type_index.hpp
@@ -11,7 +11,7 @@
 #include <boost/config.hpp>
 #if defined(BOOST_NO_CXX11_HDR_TYPEINDEX)
 #define BOOST_CPP_HAS_TYPE_INDEX 0
-#define BOOST_CPP_TYPE_INDEX_NS boost::type_index
+#define BOOST_CPP_TYPE_INDEX_NS boost::typeindex
 #define BOOST_CPP_TYPE_INDEX_HDR <boost/type_index.hpp>
 #else
 #define BOOST_CPP_HAS_TYPE_INDEX 1

--- a/include/boost/config/cpp/type_index.hpp
+++ b/include/boost/config/cpp/type_index.hpp
@@ -1,0 +1,22 @@
+//  boost/config/cpp/type_index.hpp  ---------------------------------------------------//
+
+//  (C) Copyright Edward Diener 2015. 
+//  Use, modification and distribution are subject to the 
+//  Boost Software License, Version 1.0. (See accompanying file 
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(BOOST_CONFIG_CPP_TYPE_INDEX_HPP)
+#define BOOST_CONFIG_CPP_TYPE_INDEX_HPP
+
+#include <boost/config.hpp>
+#if defined(BOOST_NO_CXX11_HDR_TYPEINDEX)
+#define BOOST_CPP_HAS_TYPE_INDEX 0
+#define BOOST_CPP_TYPE_INDEX_NS boost::type_index
+#define BOOST_CPP_TYPE_INDEX_HDR <boost/type_index.hpp>
+#else
+#define BOOST_CPP_HAS_TYPE_INDEX 1
+#define BOOST_CPP_TYPE_INDEX_NS std
+#define BOOST_CPP_TYPE_INDEX_HDR <typeindex>
+#endif
+
+#endif // !defined(BOOST_CONFIG_CPP_TYPE_INDEX_HPP)

--- a/include/boost/config/cpp/type_traits.hpp
+++ b/include/boost/config/cpp/type_traits.hpp
@@ -1,0 +1,22 @@
+//  boost/config/cpp/type_traits.hpp  ---------------------------------------------------//
+
+//  (C) Copyright Edward Diener 2015. 
+//  Use, modification and distribution are subject to the 
+//  Boost Software License, Version 1.0. (See accompanying file 
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(BOOST_CONFIG_CPP_TYPE_TRAITS_HPP)
+#define BOOST_CONFIG_CPP_TYPE_TRAITS_HPP
+
+#include <boost/config.hpp>
+#if defined(BOOST_NO_CXX11_HDR_TYPE_TRAITS)
+#define BOOST_CPP_HAS_TYPE_TRAITS 0
+#define BOOST_CPP_TYPE_TRAITS_NS boost
+#define BOOST_CPP_TYPE_TRAITS_HDR <boost/type_traits.hpp>
+#else
+#define BOOST_CPP_HAS_TYPE_TRAITS 1
+#define BOOST_CPP_TYPE_TRAITS_NS std
+#define BOOST_CPP_TYPE_TRAITS_HDR <type_traits>
+#endif
+
+#endif // !defined(BOOST_CONFIG_CPP_TYPE_TRAITS_HPP)

--- a/include/boost/config/cpp/unordered_map.hpp
+++ b/include/boost/config/cpp/unordered_map.hpp
@@ -1,0 +1,22 @@
+//  boost/config/cpp/unordered_map.hpp  ---------------------------------------------------//
+
+//  (C) Copyright Edward Diener 2015. 
+//  Use, modification and distribution are subject to the 
+//  Boost Software License, Version 1.0. (See accompanying file 
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(BOOST_CONFIG_CPP_UNORDERED_MAP_HPP)
+#define BOOST_CONFIG_CPP_UNORDERED_MAP_HPP
+
+#include <boost/config.hpp>
+#if defined(BOOST_NO_CXX11_HDR_UNORDERED_MAP)
+#define BOOST_CPP_HAS_UNORDERED_MAP 0
+#define BOOST_CPP_UNORDERED_MAP_NS boost
+#define BOOST_CPP_UNORDERED_MAP_HDR <boost/unordered_map.hpp>
+#else
+#define BOOST_CPP_HAS_UNORDERED_MAP 1
+#define BOOST_CPP_UNORDERED_MAP_NS std
+#define BOOST_CPP_UNORDERED_MAP_HDR <unordered_map>
+#endif
+
+#endif // !defined(BOOST_CONFIG_CPP_UNORDERED_MAP_HPP)

--- a/include/boost/config/cpp/unordered_multimap.hpp
+++ b/include/boost/config/cpp/unordered_multimap.hpp
@@ -1,0 +1,22 @@
+//  boost/config/cpp/unordered_multimap.hpp  ---------------------------------------------------//
+
+//  (C) Copyright Edward Diener 2015. 
+//  Use, modification and distribution are subject to the 
+//  Boost Software License, Version 1.0. (See accompanying file 
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(BOOST_CONFIG_CPP_UNORDERED_MULTIMAP_HPP)
+#define BOOST_CONFIG_CPP_UNORDERED_MULTIMAP_HPP
+
+#include <boost/config.hpp>
+#if defined(BOOST_NO_CXX11_HDR_UNORDERED_MAP)
+#define BOOST_CPP_HAS_UNORDERED_MULTIMAP 0
+#define BOOST_CPP_UNORDERED_MULTIMAP_NS boost
+#define BOOST_CPP_UNORDERED_MULTIMAP_HDR <boost/unordered_map.hpp>
+#else
+#define BOOST_CPP_HAS_UNORDERED_MULTIMAP 1
+#define BOOST_CPP_UNORDERED_MULTIMAP_NS std
+#define BOOST_CPP_UNORDERED_MULTIMAP_HDR <unordered_map>
+#endif
+
+#endif // !defined(BOOST_CONFIG_CPP_UNORDERED_MULTIMAP_HPP)

--- a/include/boost/config/cpp/unordered_multiset.hpp
+++ b/include/boost/config/cpp/unordered_multiset.hpp
@@ -1,0 +1,22 @@
+//  boost/config/cpp/unordered_multiset.hpp  ---------------------------------------------------//
+
+//  (C) Copyright Edward Diener 2015. 
+//  Use, modification and distribution are subject to the 
+//  Boost Software License, Version 1.0. (See accompanying file 
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(BOOST_CONFIG_CPP_UNORDERED_MULTISET_HPP)
+#define BOOST_CONFIG_CPP_UNORDERED_MULTISET_HPP
+
+#include <boost/config.hpp>
+#if defined(BOOST_NO_CXX11_HDR_UNORDERED_SET)
+#define BOOST_CPP_HAS_UNORDERED_MULTISET 0
+#define BOOST_CPP_UNORDERED_MULTISET_NS boost
+#define BOOST_CPP_UNORDERED_MULTISET_HDR <boost/unordered_set.hpp>
+#else
+#define BOOST_CPP_HAS_UNORDERED_MULTISET 1
+#define BOOST_CPP_UNORDERED_MULTISET_NS std
+#define BOOST_CPP_UNORDERED_MULTISET_HDR <unordered_set>
+#endif
+
+#endif // !defined(BOOST_CONFIG_CPP_UNORDERED_MULTISET_HPP)

--- a/include/boost/config/cpp/unordered_set.hpp
+++ b/include/boost/config/cpp/unordered_set.hpp
@@ -1,0 +1,22 @@
+//  boost/config/cpp/unordered_set.hpp  ---------------------------------------------------//
+
+//  (C) Copyright Edward Diener 2015. 
+//  Use, modification and distribution are subject to the 
+//  Boost Software License, Version 1.0. (See accompanying file 
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(BOOST_CONFIG_CPP_UNORDERED_SET_HPP)
+#define BOOST_CONFIG_CPP_UNORDERED_SET_HPP
+
+#include <boost/config.hpp>
+#if defined(BOOST_NO_CXX11_HDR_UNORDERED_SET)
+#define BOOST_CPP_HAS_UNORDERED_SET 0
+#define BOOST_CPP_UNORDERED_SET_NS boost
+#define BOOST_CPP_UNORDERED_SET_HDR <boost/unordered_set.hpp>
+#else
+#define BOOST_CPP_HAS_UNORDERED_SET 1
+#define BOOST_CPP_UNORDERED_SET_NS std
+#define BOOST_CPP_UNORDERED_SET_HDR <unordered_set>
+#endif
+
+#endif // !defined(BOOST_CONFIG_CPP_UNORDERED_SET_HPP)


### PR DESCRIPTION
I wrote tests for these macros for each library mentioned as .ipp files. Then I realized that these tests need to be added as regular tests for the appropriate Boost libraries themselves as the tests in Boost.config would produce dependencies on these other Boost libraries, which of course we do not want. If my set of macros is added to Boost.config I will create PRs for all the libraries mentioned with the appropriate test to exercise this added Boost.config set of macros.

The macros added here are not automatically brought in when 

    #include <boost/config.h>

is used, as my documentation for them explains.