### PR TITLE
Add another constexpr test

### DIFF
--- a/test/boost_no_constexpr.ipp
+++ b/test/boost_no_constexpr.ipp
@@ -66,6 +66,13 @@ int test()
 {
   int i = square(5);
   quiet_warning(i);
+
+  switch (i)
+  {
+  case a:
+    break;
+  }
+
   return 0;
 }
 


### PR DESCRIPTION
MSVC 14 RC doesn't call the constexpr conversion operator in some cases.
It complains:
boost_no_constexpr.ipp(72): error C2051: case expression not constant