### PR TITLE
Update for VS 2015 RTM

### DIFF
--- a/include/boost/config/compiler/visualc.hpp
+++ b/include/boost/config/compiler/visualc.hpp
@@ -284,7 +284,7 @@
 #endif
 
 //
-// last known and checked version is 19.00.23107 (VC++ 2015 RTM):
+// last known and checked version is 19.00.23026 (VC++ 2015 RTM):
 #if (_MSC_VER > 1900)
 #  if defined(BOOST_ASSERT_CONFIG)
 #     error "Unknown compiler version - please run the configure tests and report the results"

--- a/include/boost/config/compiler/visualc.hpp
+++ b/include/boost/config/compiler/visualc.hpp
@@ -284,8 +284,8 @@
 #endif
 
 //
-// last known and checked version is 19.00.22816 (VC++ 2015 RC):
-#if (_MSC_VER > 1800 && _MSC_FULL_VER > 190022816)
+// last known and checked version is 19.00.23107 (VC++ 2015 RTM):
+#if (_MSC_VER > 1900)
 #  if defined(BOOST_ASSERT_CONFIG)
 #     error "Unknown compiler version - please run the configure tests and report the results"
 #  else


### PR DESCRIPTION
Now that the final version has been released, I don't think the warning spam for every compiler update is necessary anymore. Boost builds successfully with the RTM version (except for Locale, which doesn't build at all currently).