### PR TITLE
Update for the VS14 RTM standard library

### DIFF
--- a/include/boost/config/stdlib/dinkumware.hpp
+++ b/include/boost/config/stdlib/dinkumware.hpp
@@ -176,7 +176,9 @@
 
 //  520..610 have std::addressof, but it doesn't support functions
 //
+#if !defined(_CPPLIB_VER) || _CPPLIB_VER < 650
 #  define BOOST_NO_CXX11_ADDRESSOF
+#endif
 
 #ifdef _CPPLIB_VER
 #  define BOOST_DINKUMWARE_STDLIB _CPPLIB_VER


### PR DESCRIPTION
As mentioned by Stephan T. Lavavej here:
http://lists.boost.org/Archives/boost/2014/11/217698.php
BOOST_NO_CXX11_ADDRESSOF shouldn't be necessary anymore for MSVC 14 RTM. The unit test passes.