### PR TITLE
Update for MSVC14's _HAS_AUTO_PTR_ETC

### DIFF
--- a/include/boost/config/stdlib/dinkumware.hpp
+++ b/include/boost/config/stdlib/dinkumware.hpp
@@ -172,8 +172,17 @@
 // Bug specific to VC14, 
 // See https://connect.microsoft.com/VisualStudio/feedback/details/1348277/link-error-when-using-std-codecvt-utf8-utf16-char16-t
 // and discussion here: http://blogs.msdn.com/b/vcblog/archive/2014/11/12/visual-studio-2015-preview-now-available.aspx?PageIndex=2
-#if  _CPPLIB_VER == 650
+#if defined(_CPPLIB_VER) && (_CPPLIB_VER == 650)
 #  define BOOST_NO_CXX11_HDR_CODECVT
+#endif
+
+#if defined(_CPPLIB_VER) && (_CPPLIB_VER >= 650)
+// If _HAS_AUTO_PTR_ETC is defined to 0, std::auto_ptr is not available.
+// See https://www.visualstudio.com/en-us/news/vs2015-vs.aspx#C++
+// and http://blogs.msdn.com/b/vcblog/archive/2015/06/19/c-11-14-17-features-in-vs-2015-rtm.aspx
+#  if defined(_HAS_AUTO_PTR_ETC) && (_HAS_AUTO_PTR_ETC == 0)
+#    define BOOST_NO_AUTO_PTR
+#  endif
 #endif
 
 #ifdef _CPPLIB_VER


### PR DESCRIPTION
If _HAS_AUTO_PTR_ETC is defined to 0, MSVC14's standard library implements C++17's N4190, thus removing std::auto_ptr.