### PR TITLE
Add basic platform bits for Nuxi CloudABI.

### DIFF
--- a/include/boost/config/platform/cloudabi.hpp
+++ b/include/boost/config/platform/cloudabi.hpp
@@ -1,0 +1,18 @@
+//       Copyright Nuxi, https://nuxi.nl/ 2015.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE_1_0.txt or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+
+#define BOOST_PLATFORM "CloudABI"
+
+#define BOOST_HAS_DIRENT_H
+#define BOOST_HAS_STDINT_H
+#define BOOST_HAS_UNISTD_H
+
+#define BOOST_HAS_CLOCK_GETTIME
+#define BOOST_HAS_EXPM1
+#define BOOST_HAS_GETTIMEOFDAY
+#define BOOST_HAS_LOG1P
+#define BOOST_HAS_NANOSLEEP
+#define BOOST_HAS_PTHREADS
+#define BOOST_HAS_SCHED_YIELD

--- a/include/boost/config/select_platform_config.hpp
+++ b/include/boost/config/select_platform_config.hpp
@@ -80,6 +80,10 @@
 #elif defined(__VMS) 
 // VMS:
 #  define BOOST_PLATFORM_CONFIG "boost/config/platform/vms.hpp" 
+
+#elif defined(__CloudABI__)
+// Nuxi CloudABI:
+#  define BOOST_PLATFORM_CONFIG "boost/config/platform/cloudabi.hpp"
 #else
 
 #  if defined(unix) \


### PR DESCRIPTION
Nuxi CloudABI is a POSIX-like runtime environment purely built on the
principle of capability-based security[1]. It allows you to run
arbitrary untrusted binaries directly on top of a UNIX kernel without
compromising system integrity.

This change adds a basic platform configuration that defines a small set
of options that allow it to build most of the Boost sources. The next
step is to send out small fixes to individual libraries that don't build
yet.

[1] Nuxi CloudABI: https://github.com/NuxiNL/cloudlibc