### PR TITLE
Guard attribute names with double underscores

### DIFF
--- a/include/boost/config/compiler/clang.hpp
+++ b/include/boost/config/compiler/clang.hpp
@@ -261,7 +261,7 @@
 #endif
 
 // Clang has supported the 'unused' attribute since the first release.
-#define BOOST_ATTRIBUTE_UNUSED __attribute__((unused))
+#define BOOST_ATTRIBUTE_UNUSED __attribute__((__unused__))
 
 #ifndef BOOST_COMPILER
 #  define BOOST_COMPILER "Clang version " __clang_version__

--- a/include/boost/config/compiler/gcc.hpp
+++ b/include/boost/config/compiler/gcc.hpp
@@ -276,7 +276,7 @@
 //
 // Unused attribute:
 #if __GNUC__ >= 4
-#  define BOOST_ATTRIBUTE_UNUSED __attribute__((unused))
+#  define BOOST_ATTRIBUTE_UNUSED __attribute__((__unused__))
 #endif
 
 #ifndef BOOST_COMPILER


### PR DESCRIPTION
Both gcc and clang (since their early versions like gcc-2.9.5 and clang-1.0) accept attribute names with double underscores to avoid macro interference. So it's better to guard attribute names with double underscores, but there are unguarded ones in `clang.hpp` and `gcc.hpp`: 
```
#  define BOOST_ATTRIBUTE_UNUSED __attribute__((unused))
```
This PR fix this.