### PR TITLE
Make cstdint.hpp work on QNX 6.6

### DIFF
--- a/include/boost/cstdint.hpp
+++ b/include/boost/cstdint.hpp
@@ -69,7 +69,7 @@
 
 # endif
 
-#ifdef __QNX__
+#if defined(__QNX__) && defined(__EXT_QNX) 
 
 // QNX (Dinkumware stdlib) defines these as non-standard names.
 // Reflect to the standard names.


### PR DESCRIPTION
Before this commit we were using some QNX special extensions which have been deprecated, let's not use them unless QNX is built with extensions enabled.