### PR TITLE
Do not use Windows ANSI APIs when targetting WinRT

### DIFF
--- a/include/boost/config/platform/win32.hpp
+++ b/include/boost/config/platform/win32.hpp
@@ -74,6 +74,14 @@
 #  define BOOST_HAS_GETSYSTEMTIMEASFILETIME
 #endif
 
+//
+// Windows Runtime
+//
+#if defined(WINAPI_FAMILY) && \
+  (WINAPI_FAMILY == WINAPI_FAMILY_APP || WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP)
+#  define BOOST_NO_ANSI_APIS
+#endif
+
 #ifndef BOOST_DISABLE_WIN32
 // WEK: Added
 #define BOOST_HAS_FTIME


### PR DESCRIPTION
(This is a similar PR as https://github.com/boostorg/config/pull/16 but with the difference that it doesn't pull in a dependency on Boost.Predef)

When targeting WinRT (phone, store, universal) we do not want to use ANSI versions of Windows APIS as a lot of the old win32 ansi apis are missing, therefore let's skip them altogether.

