### PR TITLE
Provide BOOST_RESTRICT and BOOST_NO_RESTRICT_REFERENCES

### DIFF
--- a/doc/macro_reference.qbk
+++ b/doc/macro_reference.qbk
@@ -209,6 +209,9 @@ Pointers to members don't work when used as template parameters.
 The compiler misreads 8.5.1, treating classes as non-aggregate if they
 contain private or protected member functions.
 ]]
+[[`BOOST_NO_RESTRICT_REFERENCES`][Compiler][
+Compiler-specific `restrict` keyword can not be applied to references.
+]]
 [[`BOOST_NO_RTTI`][Compiler][
 The compiler may (or may not) have the typeid operator, but RTTI on the dynamic type
 of an object is not supported.
@@ -1135,6 +1138,21 @@ This piece of macro magic joins the two arguments together, even when one of
 the arguments is itself a macro (see 16.3.1 in C++ standard). This is normally
 used to create a mangled name in combination with a predefined macro such a
 \_\_LINE__.
+]]
+[[`BOOST_RESTRICT`][
+This macro can be used in place of the compiler specific variant of the C99 `restrict` keyword to
+notify the compiler that, for the lifetime of the qualified pointer variable, only it and its
+derivative value will be used to gain access to the object it references. This limits the effect of
+pointer aliasing and helps the optimizers in generating better code. However, i this condition is
+violated, undefined behavior may occurs.
+
+Usage example:
+``
+  void perform_computation( float* BOOST_RESTRICT in, float* BOOST_RESTRICT out )
+  {
+    *out = *in * 0.5f;
+  }
+``
 ]]
 [[`BOOST_FORCEINLINE`][
 This macro can be used in place of the `inline` keyword to instruct the compiler

--- a/include/boost/config/suffix.hpp
+++ b/include/boost/config/suffix.hpp
@@ -583,6 +583,25 @@ namespace std{ using ::type_info; }
 #  define BOOST_GPU_ENABLED
 #  endif
 
+// BOOST_RESTRICT ---------------------------------------------//
+// Macro to use in place of 'restrict' keyword variants
+#if !defined(BOOST_RESTRICT)
+#  if defined(_MSC_VER)
+#    define BOOST_RESTRICT __restrict
+#    if !defined(BOOST_NO_RESTRICT_REFERENCES)
+#      define BOOST_NO_RESTRICT_REFERENCES
+#    endif
+#  elif defined(__GNUC__) && __GNUC__ > 3
+     // Clang also defines __GNUC__ (as 4)
+#    define BOOST_RESTRICT __restrict__
+#  else
+#    define BOOST_RESTRICT
+#    if !defined(BOOST_NO_RESTRICT_REFERENCES)
+#      define BOOST_NO_RESTRICT_REFERENCES
+#    endif
+#  endif
+#endif
+
 // BOOST_FORCEINLINE ---------------------------------------------//
 // Macro to use in place of 'inline' to force a function to be inline
 #if !defined(BOOST_FORCEINLINE)
@@ -604,7 +623,7 @@ namespace std{ using ::type_info; }
 #  elif defined(__GNUC__) && __GNUC__ > 3
      // Clang also defines __GNUC__ (as 4)
 #    if defined(__CUDACC__)
-       // nvcc doesn't always parse __noinline__, 
+       // nvcc doesn't always parse __noinline__,
        // see: https://svn.boost.org/trac/boost/ticket/9392
 #      define BOOST_NOINLINE __attribute__ ((noinline))
 #    else


### PR DESCRIPTION
Provide support for :+1: 
- portable restrict kywrod as BOST_RESTRICT
- indicator to check i restrict can or can not be applied to references
