### PR TITLE
Fix Trac 11852: CUDA in C++03 Mode and __float128

### DIFF
--- a/include/boost/config/compiler/clang.hpp
+++ b/include/boost/config/compiler/clang.hpp
@@ -57,16 +57,25 @@
 #define BOOST_HAS_LONG_LONG
 
 //
-// We disable this if the compiler is really nvcc as it
-// doesn't actually support __int128 as of CUDA_VERSION=5000
+// We disable this if the compiler is really nvcc with C++03 as it
+// doesn't actually support __int128 as of CUDA_VERSION=7500
 // even though it defines __SIZEOF_INT128__.
 // See https://svn.boost.org/trac/boost/ticket/10418
+//     https://svn.boost.org/trac/boost/ticket/11852
 // Only re-enable this for nvcc if you're absolutely sure
 // of the circumstances under which it's supported.
 // Similarly __SIZEOF_INT128__ is defined when targetting msvc
 // compatibility even though the required support functions are absent.
 //
-#if defined(__SIZEOF_INT128__) && !defined(__CUDACC__) && !defined(_MSC_VER)
+#if defined(__CUDACC__)
+#  if defined(BOOST_GCC_CXX11)
+#    define BOOST_NVCC_CXX11
+#  else
+#    define BOOST_NVCC_CXX03
+#  endif
+#endif
+
+#if defined(__SIZEOF_INT128__) && !defined(BOOST_NVCC_CXX03) && !defined(_MSC_VER)
 #  define BOOST_HAS_INT128
 #endif
 

--- a/include/boost/config/compiler/gcc.hpp
+++ b/include/boost/config/compiler/gcc.hpp
@@ -133,14 +133,23 @@
 //
 // Recent GCC versions have __int128 when in 64-bit mode.
 //
-// We disable this if the compiler is really nvcc as it
+// We disable this if the compiler is really nvcc with C++03 as it
 // doesn't actually support __int128 as of CUDA_VERSION=7500
 // even though it defines __SIZEOF_INT128__.
 // See https://svn.boost.org/trac/boost/ticket/8048
+//     https://svn.boost.org/trac/boost/ticket/11852
 // Only re-enable this for nvcc if you're absolutely sure
 // of the circumstances under which it's supported:
 //
-#if defined(__SIZEOF_INT128__) && !defined(__CUDACC__)
+#if defined(__CUDACC__)
+#  if defined(BOOST_GCC_CXX11)
+#    define BOOST_NVCC_CXX11
+#  else
+#    define BOOST_NVCC_CXX03
+#  endif
+#endif
+
+#if defined(__SIZEOF_INT128__) && !defined(BOOST_NVCC_CXX03)
 #  define BOOST_HAS_INT128
 #endif
 //
@@ -149,7 +158,7 @@
 // be including <cstddef> later anyway when we select the std lib.
 //
 // Nevertheless, as of CUDA 7.5, using __float128 with the host
-// compiler is still not supported.
+// compiler in pre-C++11 mode is still not supported.
 // See https://svn.boost.org/trac/boost/ticket/11852
 //
 #ifdef __cplusplus
@@ -157,7 +166,7 @@
 #else
 #include <stddef.h>
 #endif
-#if defined(_GLIBCXX_USE_FLOAT128) && !defined(__STRICT_ANSI__) && !defined(__CUDACC__)
+#if defined(_GLIBCXX_USE_FLOAT128) && !defined(__STRICT_ANSI__) && !defined(BOOST_NVCC_CXX03)
 # define BOOST_HAS_FLOAT128
 #endif
 

--- a/include/boost/config/compiler/gcc.hpp
+++ b/include/boost/config/compiler/gcc.hpp
@@ -134,7 +134,7 @@
 // Recent GCC versions have __int128 when in 64-bit mode.
 //
 // We disable this if the compiler is really nvcc as it
-// doesn't actually support __int128 as of CUDA_VERSION=5000
+// doesn't actually support __int128 as of CUDA_VERSION=7500
 // even though it defines __SIZEOF_INT128__.
 // See https://svn.boost.org/trac/boost/ticket/8048
 // Only re-enable this for nvcc if you're absolutely sure
@@ -148,12 +148,16 @@
 // include a std lib header to detect this - not ideal, but we'll
 // be including <cstddef> later anyway when we select the std lib.
 //
+// Nevertheless, as of CUDA 7.5, using __float128 with the host
+// compiler is still not supported.
+// See https://svn.boost.org/trac/boost/ticket/11852
+//
 #ifdef __cplusplus
 #include <cstddef>
 #else
 #include <stddef.h>
 #endif
-#if defined(_GLIBCXX_USE_FLOAT128) && !defined(__STRICT_ANSI__)
+#if defined(_GLIBCXX_USE_FLOAT128) && !defined(__STRICT_ANSI__) && !defined(__CUDACC__)
 # define BOOST_HAS_FLOAT128
 #endif
 

--- a/include/boost/config/compiler/intel.hpp
+++ b/include/boost/config/compiler/intel.hpp
@@ -514,7 +514,15 @@ template<> struct assert_intrinsic_wchar_t<unsigned short> {};
 #  define BOOST_HAS_STDINT_H
 #endif
 
-#if defined(__LP64__) && defined(__GNUC__) && (BOOST_INTEL_CXX_VERSION >= 1310) && !defined(__CUDACC__)
+#if defined(__CUDACC__)
+#  if defined(BOOST_GCC_CXX11)
+#    define BOOST_NVCC_CXX11
+#  else
+#    define BOOST_NVCC_CXX03
+#  endif
+#endif
+
+#if defined(__LP64__) && defined(__GNUC__) && (BOOST_INTEL_CXX_VERSION >= 1310) && !defined(BOOST_NVCC_CXX03)
 #  define BOOST_HAS_INT128
 #endif
 


### PR DESCRIPTION
Fix trac issue
  https://svn.boost.org/trac/boost/ticket/11852

Similar to
     https://svn.boost.org/trac/boost/ticket/8048

`__float128` is still unsupported when compiling with nvcc *in non-C++11 mode* (tested with `CUDA 7.5.18`). First noticed with the latest release (`1.60.0`) and `GCC 4.8.5` but should affect all previous releases depending on used modules.

~~In my case, I triggered it with the components
  `program_options regex filesystem system thread math_tr1`
enabled.~~

The reason this is triggered in headers is that `boost 1.60.0` introduced `__float128` type traits in [type_traits/is_floating_point.hpp](https://github.com/boostorg/type_traits/blob/boost-1.60.0/include/boost/type_traits/is_floating_point.hpp#L24-L26) which were not implemented in the previous release [1.59.0](https://github.com/boostorg/type_traits/blob/boost-1.59.0/include/boost/type_traits/is_floating_point.hpp).