### PR TITLE
Enabled the use of the atomic header in libc++

### DIFF
--- a/include/boost/config/stdlib/libcpp.hpp
+++ b/include/boost/config/stdlib/libcpp.hpp
@@ -62,7 +62,10 @@
 #  define BOOST_NO_CXX11_HDR_FUTURE
 #  define BOOST_NO_CXX11_HDR_TYPE_TRAITS
 #  define BOOST_NO_CXX11_ATOMIC_SMART_PTR
+
+#if _LIBCPP_VERSION < 3700
 #  define BOOST_NO_CXX11_HDR_ATOMIC
+#endif
 
 // libc++ uses a non-standard messages_base
 #define BOOST_NO_STD_MESSAGES


### PR DESCRIPTION
BOOST_NO_CXX11_HDR_ATOMIC appears to be defined always when libc++ is used.

Looking at the rationale http://lists.boost.org/Archives/boost/2014/02/211902.php , it references the following bug in libc++ https://llvm.org/bugs/show_bug.cgi?id=18097 . This bug appears to be fixed. At least, on my machine (OS X (Apple LLVM version 7.0.2 (clang-700.1.81)) with _LIBCPP_VERSION == 1101) all the failure tests on that bug report appears to pass.

An annoyance is that the libc++ version does not appear to be bumped consistently. Before the fix, _LIBCPP_VERSION==1101, and after the fix, _LIBCPP_VERSION is still 1101 for quite a while looking at http://llvm.org/viewvc/llvm-project/libcxx/trunk/include/__config?view=log

Testing against _LIBCPP_VERSION < 3700 thus seems to be the safest bet even though it will exclude my current machine.