### PR TITLE
Fix for Clang 3.4 (regression due to unguarded use of __is_identifier macro)

### DIFF
--- a/include/boost/config/compiler/clang.hpp
+++ b/include/boost/config/compiler/clang.hpp
@@ -27,6 +27,13 @@
 #define __has_attribute(x) 0
 #endif
 
+// __is_identifier(x) returns 0 if x is a keyword (or a keyword-like identifier).
+// Because we use __is_identifier(x) to check the availability of compiler features
+// by asking if x is a keyword, the reasonable default of __is_identifier(x) is 1.
+#ifndef __is_identifier
+#define __is_identifier(x) 1
+#endif
+
 #if !__has_feature(cxx_exceptions) && !defined(BOOST_NO_EXCEPTIONS)
 #  define BOOST_NO_EXCEPTIONS
 #endif


### PR DESCRIPTION
`__is_identifier` macro is introduced in Clang 3.5. It is not supported in Clang 3.4 (released in 2014) or previous versions. Thus, f84f27c366cc5028587efc1e34808f141ab77861 breaks Clang 3.4. We need to guard the macro by either way of:

(A)
```
#ifndef __is_identifier
#define __is_identifier(x) 1
#endif
```
Note the default value `1`. Since `__is_identifier(x)` is used to check the availability of some feature by asking "is `x` not a keyword-like word?", it makes sense to set the default value to `1`. libc++ sets the default value to 1, too.

(B)
```
#ifdef __is_identifier
#  if !__is_identifier(__int64) && !defined(__GNUC__)
#    define BOOST_HAS_MS_INT64
#  endif
#endif
```

This PR implements (A).