### PR TITLE
Added generalized build configuration test for setting any requiremen…

### DIFF
--- a/checks/config.jam
+++ b/checks/config.jam
@@ -7,6 +7,11 @@ import modules ;
 
 rule requires ( names + )
 {
+   return [ requires.set.properties $(names) : : <build>no ] ;
+}
+
+rule requires.set.properties ( names + : iftrue * : iffalse * )
+{
    local config-binding = [ modules.binding $(__name__) ] ;
 
    local result ;
@@ -14,8 +19,7 @@ rule requires ( names + )
    {
       local msg = "Boost.Config Feature Check: " ;
       msg += $(name) ;
-      result += [ check-target-builds $(config-binding:D)//$(name) $(msg:J=) : : <build>no ] ;
+      result += [ check-target-builds $(config-binding:D)//$(name) $(msg:J=) : $(iftrue) : $(iffalse) ] ;
    }
    return $(result) ;
 }
-


### PR DESCRIPTION
…t when true or false and changed the 'requires' test to work in terms of the generalized test. I have not documented the generalized test but am willing to do so. Also I do not know if there is any Boost.config test for 'requires' so I have not attempted to test the changed functionality in a formal Boost.config test, although I have tested it out from another library on which I am working to ascertain that 'requires' and the new 'requires.set.properties' rules work accordingly.