### PR TITLE
For Oracle Developer Studio

### DIFF
--- a/include/boost/config/suffix.hpp
+++ b/include/boost/config/suffix.hpp
@@ -624,7 +624,11 @@ namespace std{ using ::type_info; }
 #    define BOOST_NORETURN __declspec(noreturn)
 #  elif defined(__GNUC__)
 #    define BOOST_NORETURN __attribute__ ((__noreturn__))
-#  elif defined(__has_cpp_attribute) && !defined(__SUNPRO_CC)
+#  elif defined(__has_attribute) && defined(__SUNPRO_CC)
+#    if __has_attribute(noreturn)
+#      define BOOST_NORETURN [[noreturn]]
+#    endif
+#  elif defined(__has_cpp_attribute) 
 #    if __has_cpp_attribute(noreturn)
 #      define BOOST_NORETURN [[noreturn]]
 #    endif


### PR DESCRIPTION
__has_attribute to be used instead of __has_cpp_attribute, not remove the functionality.