### PR TITLE
Adds .gitignore to prevent tracking changes of binary compiled files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+checks/architecture/bin


### PR DESCRIPTION
Ignores files under
checks/architecture/bin

In order to maintain a clean tree after builds. 
