### PR TITLE
Disable C++14 constexpr for Intel compiler

### DIFF
--- a/include/boost/config/compiler/intel.hpp
+++ b/include/boost/config/compiler/intel.hpp
@@ -496,6 +496,11 @@ template<> struct assert_intrinsic_wchar_t<unsigned short> {};
 #  define BOOST_NO_CXX11_HDR_TUPLE
 #endif
 
+// Broken in all versions up to 17:
+#if !defined(BOOST_NO_CXX14_CONSTEXPR)
+#define BOOST_NO_CXX14_CONSTEXPR
+#endif
+
 #if (BOOST_INTEL_CXX_VERSION < 1200)
 //
 // fenv.h appears not to work with Intel prior to 12.0:


### PR DESCRIPTION
Intel compiler up to version 17.0 (on Linux) makes constexpr member functions implicitly const-qualified.

This PR is a continuation of https://github.com/boostorg/config/pull/104 and http://lists.boost.org/Archives/boost/2016/12/231859.php.