### PR TITLE
Use corrent name for libraries built with MS VS 2017 RC.

### DIFF
--- a/include/boost/config/auto_link.hpp
+++ b/include/boost/config/auto_link.hpp
@@ -161,10 +161,15 @@ BOOST_LIB_VERSION:    The Boost version, in the form x_y, for Boost version x.y.
      // vc12:
 #    define BOOST_LIB_TOOLSET "vc120"
 
+#  elif defined(BOOST_MSVC) && (BOOST_MSVC < 1910)
+
+     // vc14:
+#    define BOOST_LIB_TOOLSET "vc140"
+
 # elif defined(BOOST_MSVC)
 
-   // vc14:
-#  define BOOST_LIB_TOOLSET "vc140"
+   // vc15:
+#  define BOOST_LIB_TOOLSET "vc150"
 
 #  elif defined(__BORLANDC__)
 


### PR DESCRIPTION
Boost built with MS VS 2017 RC has -vc150 suffix.