### PR TITLE
Fix a compiling problem under Clang/C2.

### DIFF
--- a/include/boost/config/compiler/clang.hpp
+++ b/include/boost/config/compiler/clang.hpp
@@ -57,7 +57,7 @@
 #define BOOST_HAS_NRVO
 
 // Branch prediction hints
-#if defined(__has_builtin)
+#if !defined (__c2__) && defined(__has_builtin)
 #if __has_builtin(__builtin_expect)
 #define BOOST_LIKELY(x) __builtin_expect(x, 1)
 #define BOOST_UNLIKELY(x) __builtin_expect(x, 0)


### PR DESCRIPTION
In Clang/C2, __builtin_expect is defined. But using __builtin_expect end up with an compiler internal error. Use _MSC_VER to detect it's in Clang/C2, and ignore the __builtin_expect.