### PR TITLE
Update boost_no_cxx11_sfinae_expr test to fail faster

### DIFF
--- a/test/boost_no_cxx11_sfinae_expr.ipp
+++ b/test/boost_no_cxx11_sfinae_expr.ipp
@@ -27,9 +27,7 @@ struct trait {
 };
 
 template<class T>
-struct trait<T, typename ignore<decltype(&object<T>())>::type> {
-    static const int value = 1;
-};
+struct trait<T, typename ignore<decltype(&object<T>())>::type> { };
 
 template<class T>
 struct result {


### PR DESCRIPTION
Will now compile-fail for Intel C++ 13 instead of run-fail.