### PR TITLE
Define BOOST_NO_CXX11_SFINAE_EXPR in C++98 clang

### DIFF
--- a/include/boost/config/compiler/clang.hpp
+++ b/include/boost/config/compiler/clang.hpp
@@ -282,6 +282,10 @@
 #  define BOOST_NO_CXX14_VARIABLE_TEMPLATES
 #endif
 
+#if __cplusplus < 201103L
+#define BOOST_NO_CXX11_SFINAE_EXPR
+#endif
+
 #if __cplusplus < 201400
 // All versions with __cplusplus above this value seem to support this:
 #  define BOOST_NO_CXX14_DIGIT_SEPARATORS


### PR DESCRIPTION
When compiling in pre-C++11 clang mode it should be defined