### PR TITLE
add _WORKAROUND_GUARD macros for BOOST_XLCPP_ZOS

### DIFF
--- a/include/boost/detail/workaround.hpp
+++ b/include/boost/detail/workaround.hpp
@@ -90,6 +90,11 @@
 #else
 #define BOOST_GCC_WORKAROUND_GUARD 0
 #endif
+#ifndef BOOST_XLCPP_ZOS
+#define BOOST_XLCPP_ZOS_WORKAROUND_GUARD 1
+#else
+#define BOOST_XLCPP_ZOS_WORKAROUND_GUARD 0
+#endif
 #ifndef __IBMCPP__
 #define __IBMCPP___WORKAROUND_GUARD 1
 #else


### PR DESCRIPTION
I'd missed workaround.hpp. And since `__IBMCPP__` doesn't uniquely identify the z/OS compiler, I guess there should be a `_WORKAROUND_GUARD` for `BOOST_XLCPP_ZOS`...

Is there anything else that needs to be done for `BOOST_WORKAROUND()` support?
