### PR TITLE
Using 141 instead of 1410

### DIFF
--- a/include/boost/config/auto_link.hpp
+++ b/include/boost/config/auto_link.hpp
@@ -168,8 +168,8 @@ BOOST_LIB_VERSION:    The Boost version, in the form x_y, for Boost version x.y.
 
 #  elif defined(BOOST_MSVC)
 
-     // vc14.10:
-#    define BOOST_LIB_TOOLSET "vc1410"
+     // vc14.1:
+#    define BOOST_LIB_TOOLSET "vc141"
 
 #  elif defined(__BORLANDC__)
 


### PR DESCRIPTION
This PR should *not* be accepted unless the [community consensus on the mailing list](http://lists.boost.org/Archives/boost/2017/03/233543.php) converges around option 2. 
