### PR TITLE
Introduce feature-test macro BOOST_NO_CXX17_STD_RANDOM_SHUFFLE

### DIFF
--- a/doc/html/boost_config/boost_macro_reference.html
+++ b/doc/html/boost_config/boost_macro_reference.html
@@ -3770,7 +3770,7 @@
       that describe C++17 features not supported</a>
 </h3></div></div></div>
 <p>
-        The following macros describe features in the 2016 ISO C++ standard, formerly
+        The following macros describe features in the 2017 ISO C++ standard, formerly
         known as C++1z, that are not yet supported by a particular compiler or library.
       </p>
 <div class="informaltable"><table class="table">
@@ -3815,7 +3815,18 @@
                 </p>
               </td>
 </tr>
-</tbody>
+<tr>
+<td>
+                <p>
+                  <code class="computeroutput"><span class="identifier">BOOST_NO_CXX98_RANDOM_SHUFFLE</span></code>
+                </p>
+              </td>
+<td>
+                <p>
+                  The compiler does no longer support <code class="computeroutput"><span class="identifier">std</span><span class="special">::</span><span class="identifier">random_shuffle</span><span class="special">()</span></code>. It was deprecated in C++14 and is removed from C++17.
+                </p>
+              </td>
+</tr></tbody>
 </table></div>
 </div>
 <div class="section">

--- a/doc/macro_reference.qbk
+++ b/doc/macro_reference.qbk
@@ -936,13 +936,14 @@ provide compliant C++14 support.
 
 [section Macros that describe C++17 features not supported]
 
-The following macros describe features in the 2016 ISO C++ standard, formerly known as C++1z,
+The following macros describe features in the 2017 ISO C++ standard, formerly known as C++1z,
 that are not yet supported by a particular compiler or library.
 
 [table
 [[Macro ][Description ]]
 [[`BOOST_NO_CXX17_STD_APPLY`][The compiler does not support `std::apply()`.]]
 [[`BOOST_NO_CXX17_STD_INVOKE`][The compiler does not support `std::invoke()`.]]
+[[`BOOST_NO_CXX98_RANDOM_SHUFFLE`][The compiler does no longer support `std::random_shuffle()`. It was deprecated in C++14 and is removed from C++17.]]
 ]
 
 [endsect]

--- a/include/boost/config/stdlib/dinkumware.hpp
+++ b/include/boost/config/stdlib/dinkumware.hpp
@@ -190,11 +190,12 @@
 #endif
 
 #if defined(_CPPLIB_VER) && (_CPPLIB_VER >= 650)
-// If _HAS_AUTO_PTR_ETC is defined to 0, std::auto_ptr is not available.
+// If _HAS_AUTO_PTR_ETC is defined to 0, std::auto_ptr and std::random_shuffle are not available.
 // See https://www.visualstudio.com/en-us/news/vs2015-vs.aspx#C++
 // and http://blogs.msdn.com/b/vcblog/archive/2015/06/19/c-11-14-17-features-in-vs-2015-rtm.aspx
 #  if defined(_HAS_AUTO_PTR_ETC) && (_HAS_AUTO_PTR_ETC == 0)
 #    define BOOST_NO_AUTO_PTR
+#    define BOOST_NO_CXX98_RANDOM_SHUFFLE
 #  endif
 #endif
 


### PR DESCRIPTION
The algorithm std::random_shuffle was marked as deprecated in C++14 and is removed from the upcoming C++17 standard. The name itself is still reserved and library implementations may continue to ship it. In this sense, support for std::random_shuffle must be regarded as purely optional and a feature-test macro is required to test for its presence.

Signed-off-by: Daniela Engert <dani@ngrt.de>