### PR TITLE
The library implementations in MSVC 14.0 and 14.1 have both version n…

### DIFF
--- a/include/boost/config/stdlib/dinkumware.hpp
+++ b/include/boost/config/stdlib/dinkumware.hpp
@@ -163,7 +163,7 @@
 #endif
 
 // C++17 features
-#if !defined(_CPPLIB_VER) || (_CPPLIB_VER < 650) || !defined(_HAS_CXX17) || (_HAS_CXX17 == 0)
+#if !defined(_CPPLIB_VER) || (_CPPLIB_VER < 650) || !defined(BOOST_MSVC) || (BOOST_MSVC < 1910) || !defined(_HAS_CXX17) || (_HAS_CXX17 == 0)
 #  define BOOST_NO_CXX17_STD_APPLY
 #endif
 #if !defined(_CPPLIB_VER) || (_CPPLIB_VER < 650)


### PR DESCRIPTION
…umber V6.50:0009, and therefore _CPPLIB_VER is defined to 650. But the library in 14.0 does *not* have std::apply whereas the one in 14.1 *does*.

Signed-off-by: Daniela Engert <dani@ngrt.de>