### PR TITLE
Update boost_has_nl_types_h.ipp

### DIFF
--- a/test/boost_has_nl_types_h.ipp
+++ b/test/boost_has_nl_types_h.ipp
@@ -17,7 +17,7 @@ namespace boost_has_nl_types_h{
 int test()
 {
    nl_catd cat = catopen("foo", 0);
-   if(cat >= 0) catclose(cat);
+   if(cat != (nl_catd)-1) catclose(cat);
    return 0;
 }
 


### PR DESCRIPTION
clang 5 complains that comparing a `nl_catd` to an integer is not allowed.

./boost_has_nl_types_h.ipp:20:11: error: ordered comparison between pointer and zero ('nl_catd' (aka '__nl_cat_d *') and 'int')
   if(cat >= 0) catclose(cat);