### PR TITLE
Fix for the "uintptr_t is not defined" error on Linux when using the Oracle's compiler

### DIFF
--- a/include/boost/config/compiler/sunpro_cc.hpp
+++ b/include/boost/config/compiler/sunpro_cc.hpp
@@ -172,6 +172,8 @@
 #  define BOOST_NO_CXX14_VARIABLE_TEMPLATES
 #endif
 
+#define BOOST_HAS_STDINT_H
+
 // Turn on threading support for Solaris 12.
 // Ticket #11972
 #if (__SUNPRO_CC >= 0x5140) && defined(__SunOS_5_12) && !defined(BOOST_HAS_THREADS)


### PR DESCRIPTION
Lots of "uintptr_t is not defined" errors when building on Oracle Linux with
the Oracle compiler; the fix is to define BOOST_HAS_STDINT_H in the compiler's
configuration header sunpro_cc.hpp.

The corresponding ticket is https://svn.boost.org/trac/boost/ticket/13045

