### PR TITLE
Correct logic about BOOST_NO_CTYPE_FUNCTIONS

### DIFF
--- a/include/boost/config/platform/bsd.hpp
+++ b/include/boost/config/platform/bsd.hpp
@@ -62,7 +62,7 @@
 //
 // The BSD <ctype.h> has macros only, no functions:
 //
-#if !defined(__OpenBSD__) || defined(__DragonFly__)
+#if defined(__FreeBSD__) || defined(__DragonFly__)
 #  define BOOST_NO_CTYPE_FUNCTIONS
 #endif
 


### PR DESCRIPTION
Now it will no longer apply for netbsd.

netbsd: https://nxr.netbsd.org/xref/src/include/ctype.h
freebsd: https://grok.dragonflybsd.org/xref/freebsd/include/ctype.h
dragonflybsd: https://grok.dragonflybsd.org/xref/dragonfly/include/ctype.h
openbsd: https://grok.dragonflybsd.org/xref/openbsd/include/ctype.h