### PR TITLE
fix C++11 CUDA 8 nvcc compile time odeint error

### DIFF
--- a/include/boost/config/compiler/nvcc.hpp
+++ b/include/boost/config/compiler/nvcc.hpp
@@ -30,3 +30,11 @@
 #if defined(_MSC_VER)
 #  define BOOST_NO_CXX11_CONSTEXPR
 #endif
+
+// A bug in nvcc (cudafe) of CUDA 8.0 prevents use of noexcept
+// https://svn.boost.org/trac/boost/ticket/13049
+// The issue will be fixed with CUDA 9.
+#if (__CUDACC_VER__ >= 80000) && (__CUDACC_VER__ < 80100)
+#   define BOOST_NO_CXX11_NOEXCEPT
+#endif
+


### PR DESCRIPTION
fix https://svn.boost.org/trac/boost/ticket/13049

disable usage of noexcept with `BOOST_NO_CXX11_NOEXCEPT` for nvcc from CUDA 8