### PR TITLE
Cce86 cray config

### DIFF
--- a/include/boost/config/compiler/cray.hpp
+++ b/include/boost/config/compiler/cray.hpp
@@ -115,6 +115,10 @@
 #define BOOST_HAS_LONG_LONG
 #define BOOST_HAS_FLOAT128
 
+#if __cplusplus < 201400
+#define BOOST_NO_CXX11_DECLTYPE_N3276
+#endif /* __cpluspus */
+
 #endif /* _RELEASE_MINOR */
 
 

--- a/include/boost/config/compiler/cray.hpp
+++ b/include/boost/config/compiler/cray.hpp
@@ -21,9 +21,8 @@
 #  error "Unsupported Cray compiler, please try running the configure script."
 #endif
 
-#if _RELEASE_MINOR < 6
+#if _RELEASE_MINOR < 5 || __cplusplus < 201100
 #include <boost/config/compiler/common_edg.hpp>
-
 
 //
 //


### PR DESCRIPTION
Further updates to support C++03 C++11 and C++14 and releases 8.5 and 8.6 of the cray C++ compiler.