### PR TITLE
Add address model to auto_link.hpp

### DIFF
--- a/include/boost/config/auto_link.hpp
+++ b/include/boost/config/auto_link.hpp
@@ -45,6 +45,7 @@ BOOST_LIB_PREFIX
    + BOOST_LIB_TOOLSET
    + BOOST_LIB_THREAD_OPT
    + BOOST_LIB_RT_OPT
+   + BOOST_LIB_ADDRESS_MODEL_OPT
    "-"
    + BOOST_LIB_VERSION
 
@@ -68,6 +69,8 @@ BOOST_LIB_RT_OPT:     A suffix that indicates the runtime library used,
                       d      debug build (release if not present).
                       p      STLport build.
                       n      STLport build without its IOStreams.
+
+BOOST_LIB_ADDRESS_MODEL_OPT: The address model (-32 or -64)
 
 BOOST_LIB_VERSION:    The Boost version, in the form x_y, for Boost version x.y.
 
@@ -362,6 +365,16 @@ BOOST_LIB_VERSION:    The Boost version, in the form x_y, for Boost version x.y.
 #endif
 
 //
+// BOOST_LIB_ADDRESS_MODEL_OPT
+//
+
+#if defined( _M_IX86 )
+#  define BOOST_LIB_ADDRESS_MODEL_OPT "-32"
+#elif defined( _M_X64 )
+#  define BOOST_LIB_ADDRESS_MODEL_OPT "-64"
+#endif
+
+//
 // select linkage opt:
 //
 #if (defined(_DLL) || defined(_RTLDLL)) && defined(BOOST_DYN_LINK)
@@ -380,6 +393,7 @@ BOOST_LIB_VERSION:    The Boost version, in the form x_y, for Boost version x.y.
       && defined(BOOST_LIB_TOOLSET) \
       && defined(BOOST_LIB_THREAD_OPT) \
       && defined(BOOST_LIB_RT_OPT) \
+      && defined(BOOST_LIB_ADDRESS_MODEL_OPT) \
       && defined(BOOST_LIB_VERSION)
 
 #ifdef BOOST_AUTO_LINK_TAGGED
@@ -393,14 +407,14 @@ BOOST_LIB_VERSION:    The Boost version, in the form x_y, for Boost version x.y.
 #     pragma message ("Linking to lib file: " BOOST_STRINGIZE(BOOST_LIB_NAME) ".lib")
 #  endif
 #elif defined(BOOST_LIB_BUILDID)
-#  pragma comment(lib, BOOST_LIB_PREFIX BOOST_STRINGIZE(BOOST_LIB_NAME) "-" BOOST_LIB_TOOLSET BOOST_LIB_THREAD_OPT BOOST_LIB_RT_OPT "-" BOOST_LIB_VERSION "-" BOOST_STRINGIZE(BOOST_LIB_BUILDID) ".lib")
+#  pragma comment(lib, BOOST_LIB_PREFIX BOOST_STRINGIZE(BOOST_LIB_NAME) "-" BOOST_LIB_TOOLSET BOOST_LIB_THREAD_OPT BOOST_LIB_RT_OPT BOOST_LIB_ADDRESS_MODEL_OPT "-" BOOST_LIB_VERSION "-" BOOST_STRINGIZE(BOOST_LIB_BUILDID) ".lib")
 #  ifdef BOOST_LIB_DIAGNOSTIC
-#     pragma message ("Linking to lib file: " BOOST_LIB_PREFIX BOOST_STRINGIZE(BOOST_LIB_NAME) "-" BOOST_LIB_TOOLSET BOOST_LIB_THREAD_OPT BOOST_LIB_RT_OPT "-" BOOST_LIB_VERSION "-" BOOST_STRINGIZE(BOOST_LIB_BUILDID) ".lib")
+#     pragma message ("Linking to lib file: " BOOST_LIB_PREFIX BOOST_STRINGIZE(BOOST_LIB_NAME) "-" BOOST_LIB_TOOLSET BOOST_LIB_THREAD_OPT BOOST_LIB_RT_OPT BOOST_LIB_ADDRESS_MODEL_OPT "-" BOOST_LIB_VERSION "-" BOOST_STRINGIZE(BOOST_LIB_BUILDID) ".lib")
 #  endif
 #else
-#  pragma comment(lib, BOOST_LIB_PREFIX BOOST_STRINGIZE(BOOST_LIB_NAME) "-" BOOST_LIB_TOOLSET BOOST_LIB_THREAD_OPT BOOST_LIB_RT_OPT "-" BOOST_LIB_VERSION ".lib")
+#  pragma comment(lib, BOOST_LIB_PREFIX BOOST_STRINGIZE(BOOST_LIB_NAME) "-" BOOST_LIB_TOOLSET BOOST_LIB_THREAD_OPT BOOST_LIB_RT_OPT BOOST_LIB_ADDRESS_MODEL_OPT "-" BOOST_LIB_VERSION ".lib")
 #  ifdef BOOST_LIB_DIAGNOSTIC
-#     pragma message ("Linking to lib file: " BOOST_LIB_PREFIX BOOST_STRINGIZE(BOOST_LIB_NAME) "-" BOOST_LIB_TOOLSET BOOST_LIB_THREAD_OPT BOOST_LIB_RT_OPT "-" BOOST_LIB_VERSION ".lib")
+#     pragma message ("Linking to lib file: " BOOST_LIB_PREFIX BOOST_STRINGIZE(BOOST_LIB_NAME) "-" BOOST_LIB_TOOLSET BOOST_LIB_THREAD_OPT BOOST_LIB_RT_OPT BOOST_LIB_ADDRESS_MODEL_OPT "-" BOOST_LIB_VERSION ".lib")
 #  endif
 #endif
 
@@ -430,6 +444,9 @@ BOOST_LIB_VERSION:    The Boost version, in the form x_y, for Boost version x.y.
 #endif
 #if defined(BOOST_LIB_RT_OPT)
 #  undef BOOST_LIB_RT_OPT
+#endif
+#if defined(BOOST_LIB_ADDRESS_MODEL_OPT)
+#  undef BOOST_LIB_ADDRESS_MODEL_OPT
 #endif
 #if defined(BOOST_LIB_LINK_OPT)
 #  undef BOOST_LIB_LINK_OPT


### PR DESCRIPTION
This corresponds to boostorg/boost#147 and should be applied in tandem with it.

I am not sure whether the tagged layout needs the address model too, so I've left it untouched for now.