### PR TITLE
Fix references to headers in the docs

### DIFF
--- a/doc/config.qbk
+++ b/doc/config.qbk
@@ -22,7 +22,7 @@ Distributed under the Boost Software License, Version 1.0.
 [def __BOOST_REGRESSION_TEST_DRIVER__ [@../../../../tools/regression/doc/index.html boost regression test driver]]
 [def __BOOST_CONFIG_HEADER__ [@../../../../boost/config.hpp <boost/config.hpp>]]
 [def __BOOST_CONFIG_USER_HEADER__ [@../../../../boost/config/user.hpp <boost/config/user.hpp>]]
-[def __BOOST_CONFIG_SUFFIX_HEADER__ [@../../../../boost/config/user.hpp <boost/config/suffix.hpp>]]
+[def __BOOST_CONFIG_SUFFIX_HEADER__ [@../../../../boost/config/detail/suffix.hpp <boost/config/detail/suffix.hpp>]]
 [def __BOOST_CONFIG_DIR__ ['<boost-root>]`/boost/config/`]
 
 

--- a/doc/guidelines.qbk
+++ b/doc/guidelines.qbk
@@ -191,9 +191,9 @@ modifying this file as it breaks dependencies for everyone. This file should
 include only "boilerplate" configuration code, and generally should change
 only when new macros are added.
 
-[@../../../../boost/config/select_compiler_config.hpp <boost/config/select_compiler_config.hpp>],
-[@../../../../boost/config/select_platform_config.hpp <boost/config/select_platform_config.hpp>] and
-[@../../../../boost/config/select_stdlib_config.hpp <boost/config/select_stdlib_config.hpp>]
+[@../../../../boost/config/detail/select_compiler_config.hpp <boost/config/detail/select_compiler_config.hpp>],
+[@../../../../boost/config/detail/select_platform_config.hpp <boost/config/detail/select_platform_config.hpp>] and
+[@../../../../boost/config/detail/select_stdlib_config.hpp <boost/config/detail/select_stdlib_config.hpp>]
 are included by default and should change only if support for a new
 compiler/standard library/platform is added.
 

--- a/doc/html/boost_config/acknowledgements.html
+++ b/doc/html/boost_config/acknowledgements.html
@@ -3,7 +3,7 @@
 <meta http-equiv="Content-Type" content="text/html; charset=US-ASCII">
 <title>Acknowledgements</title>
 <link rel="stylesheet" href="../../../../../doc/src/boostbook.css" type="text/css">
-<meta name="generator" content="DocBook XSL Stylesheets V1.77.1">
+<meta name="generator" content="DocBook XSL Stylesheets V1.79.1">
 <link rel="home" href="../index.html" title="Boost.Config">
 <link rel="up" href="../index.html" title="Boost.Config">
 <link rel="prev" href="rationale.html" title="Rationale">

--- a/doc/html/boost_config/boost_macro_reference.html
+++ b/doc/html/boost_config/boost_macro_reference.html
@@ -3,7 +3,7 @@
 <meta http-equiv="Content-Type" content="text/html; charset=US-ASCII">
 <title>Boost Macro Reference</title>
 <link rel="stylesheet" href="../../../../../doc/src/boostbook.css" type="text/css">
-<meta name="generator" content="DocBook XSL Stylesheets V1.77.1">
+<meta name="generator" content="DocBook XSL Stylesheets V1.79.1">
 <link rel="home" href="../index.html" title="Boost.Config">
 <link rel="up" href="../index.html" title="Boost.Config">
 <link rel="prev" href="../index.html" title="Boost.Config">
@@ -26,7 +26,7 @@
 <div class="titlepage"><div><div><h2 class="title" style="clear: both">
 <a name="boost_config.boost_macro_reference"></a><a class="link" href="boost_macro_reference.html" title="Boost Macro Reference">Boost Macro Reference</a>
 </h2></div></div></div>
-<div class="toc"><dl>
+<div class="toc"><dl class="toc">
 <dt><span class="section"><a href="boost_macro_reference.html#boost_config.boost_macro_reference.macros_that_describe_c__03_defects">Macros
       that describe C++03 defects</a></span></dt>
 <dt><span class="section"><a href="boost_macro_reference.html#boost_config.boost_macro_reference.macros_that_describe_optional_features">Macros
@@ -3019,6 +3019,18 @@
 <tr>
 <td>
                 <p>
+                  <code class="computeroutput"><span class="identifier">BOOST_NO_CXX11_POINTER_TRAITS</span></code>
+                </p>
+              </td>
+<td>
+                <p>
+                  The standard library does not provide a C++11 version of <code class="computeroutput"><span class="identifier">std</span><span class="special">::</span><span class="identifier">pointer_traits</span></code> in &lt;memory&gt;.
+                </p>
+              </td>
+</tr>
+<tr>
+<td>
+                <p>
                   <code class="computeroutput"><span class="identifier">BOOST_NO_CXX11_RANGE_BASED_FOR</span></code>
                 </p>
               </td>
@@ -5844,7 +5856,7 @@
 <a name="boost_config.boost_macro_reference.macros_for_libraries_with_separate_source_code"></a><a class="link" href="boost_macro_reference.html#boost_config.boost_macro_reference.macros_for_libraries_with_separate_source_code" title="Macros for libraries with separate source code">Macros
       for libraries with separate source code</a>
 </h3></div></div></div>
-<div class="toc"><dl>
+<div class="toc"><dl class="toc">
 <dt><span class="section"><a href="boost_macro_reference.html#boost_config.boost_macro_reference.macros_for_libraries_with_separate_source_code.macros_controlling_shared_library_symbol_visibility">Macros
         controlling shared library symbol visibility</a></span></dt>
 <dt><span class="section"><a href="boost_macro_reference.html#boost_config.boost_macro_reference.macros_for_libraries_with_separate_source_code.abi_fixing">ABI

--- a/doc/html/boost_config/build_config.html
+++ b/doc/html/boost_config/build_config.html
@@ -3,7 +3,7 @@
 <meta http-equiv="Content-Type" content="text/html; charset=US-ASCII">
 <title>Build Time Configuration</title>
 <link rel="stylesheet" href="../../../../../doc/src/boostbook.css" type="text/css">
-<meta name="generator" content="DocBook XSL Stylesheets V1.77.1">
+<meta name="generator" content="DocBook XSL Stylesheets V1.79.1">
 <link rel="home" href="../index.html" title="Boost.Config">
 <link rel="up" href="../index.html" title="Boost.Config">
 <link rel="prev" href="boost_macro_reference.html" title="Boost Macro Reference">

--- a/doc/html/boost_config/cstdint.html
+++ b/doc/html/boost_config/cstdint.html
@@ -3,7 +3,7 @@
 <meta http-equiv="Content-Type" content="text/html; charset=US-ASCII">
 <title>Standard Integer Types</title>
 <link rel="stylesheet" href="../../../../../doc/src/boostbook.css" type="text/css">
-<meta name="generator" content="DocBook XSL Stylesheets V1.77.1">
+<meta name="generator" content="DocBook XSL Stylesheets V1.79.1">
 <link rel="home" href="../index.html" title="Boost.Config">
 <link rel="up" href="../index.html" title="Boost.Config">
 <link rel="prev" href="build_config.html" title="Build Time Configuration">
@@ -26,7 +26,7 @@
 <div class="titlepage"><div><div><h2 class="title" style="clear: both">
 <a name="boost_config.cstdint"></a><a class="link" href="cstdint.html" title="Standard Integer Types">Standard Integer Types</a>
 </h2></div></div></div>
-<div class="toc"><dl>
+<div class="toc"><dl class="toc">
 <dt><span class="section"><a href="cstdint.html#boost_config.cstdint.overview">Overview</a></span></dt>
 <dt><span class="section"><a href="cstdint.html#boost_config.cstdint.rationale">Rationale</a></span></dt>
 <dt><span class="section"><a href="cstdint.html#boost_config.cstdint.ce"><span class="emphasis"><em>Caveat emptor</em></span></a></span></dt>

--- a/doc/html/boost_config/guidelines_for_boost_authors.html
+++ b/doc/html/boost_config/guidelines_for_boost_authors.html
@@ -3,7 +3,7 @@
 <meta http-equiv="Content-Type" content="text/html; charset=US-ASCII">
 <title>Guidelines for Boost Authors</title>
 <link rel="stylesheet" href="../../../../../doc/src/boostbook.css" type="text/css">
-<meta name="generator" content="DocBook XSL Stylesheets V1.77.1">
+<meta name="generator" content="DocBook XSL Stylesheets V1.79.1">
 <link rel="home" href="../index.html" title="Boost.Config">
 <link rel="up" href="../index.html" title="Boost.Config">
 <link rel="prev" href="cstdint.html" title="Standard Integer Types">
@@ -27,7 +27,7 @@
 <a name="boost_config.guidelines_for_boost_authors"></a><a class="link" href="guidelines_for_boost_authors.html" title="Guidelines for Boost Authors">Guidelines for
     Boost Authors</a>
 </h2></div></div></div>
-<div class="toc"><dl>
+<div class="toc"><dl class="toc">
 <dt><span class="section"><a href="guidelines_for_boost_authors.html#boost_config.guidelines_for_boost_authors.warnings">Disabling
       Compiler Warnings</a></span></dt>
 <dt><span class="section"><a href="guidelines_for_boost_authors.html#boost_config.guidelines_for_boost_authors.adding_new_defect_macros">Adding
@@ -302,7 +302,7 @@
         one specific API (for example <code class="computeroutput"><span class="identifier">BOOST_HAS_NL_TYPES_H</span></code>
         rather than <code class="computeroutput"><span class="identifier">BOOST_HAS_CATOPEN</span></code>).
         If the macro describes a POSIX feature group, then add boilerplate code to
-        <a href="../../../../../boost/config/user.hpp" target="_top">&lt;boost/config/suffix.hpp&gt;</a>
+        <a href="../../../../../boost/config/detail/suffix.hpp" target="_top">&lt;boost/config/detail/suffix.hpp&gt;</a>
         to auto-detect the feature where possible (if you are wondering why we can't
         use POSIX feature test macro directly, remember that many of these features
         can be added by third party libraries, and are not therefore identified inside
@@ -333,15 +333,15 @@
         as well.
       </p>
 <p>
-        <a href="../../../../../boost/config/user.hpp" target="_top">&lt;boost/config/suffix.hpp&gt;</a>
+        <a href="../../../../../boost/config/detail/suffix.hpp" target="_top">&lt;boost/config/detail/suffix.hpp&gt;</a>
         is always included so be careful about modifying this file as it breaks dependencies
         for everyone. This file should include only "boilerplate" configuration
         code, and generally should change only when new macros are added.
       </p>
 <p>
-        <a href="../../../../../boost/config/select_compiler_config.hpp" target="_top">&lt;boost/config/select_compiler_config.hpp&gt;</a>,
-        <a href="../../../../../boost/config/select_platform_config.hpp" target="_top">&lt;boost/config/select_platform_config.hpp&gt;</a>
-        and <a href="../../../../../boost/config/select_stdlib_config.hpp" target="_top">&lt;boost/config/select_stdlib_config.hpp&gt;</a>
+        <a href="../../../../../boost/config/detail/select_compiler_config.hpp" target="_top">&lt;boost/config/detail/select_compiler_config.hpp&gt;</a>,
+        <a href="../../../../../boost/config/detail/select_platform_config.hpp" target="_top">&lt;boost/config/detail/select_platform_config.hpp&gt;</a>
+        and <a href="../../../../../boost/config/detail/select_stdlib_config.hpp" target="_top">&lt;boost/config/detail/select_stdlib_config.hpp&gt;</a>
         are included by default and should change only if support for a new compiler/standard
         library/platform is added.
       </p>

--- a/doc/html/boost_config/rationale.html
+++ b/doc/html/boost_config/rationale.html
@@ -3,7 +3,7 @@
 <meta http-equiv="Content-Type" content="text/html; charset=US-ASCII">
 <title>Rationale</title>
 <link rel="stylesheet" href="../../../../../doc/src/boostbook.css" type="text/css">
-<meta name="generator" content="DocBook XSL Stylesheets V1.77.1">
+<meta name="generator" content="DocBook XSL Stylesheets V1.79.1">
 <link rel="home" href="../index.html" title="Boost.Config">
 <link rel="up" href="../index.html" title="Boost.Config">
 <link rel="prev" href="guidelines_for_boost_authors.html" title="Guidelines for Boost Authors">
@@ -26,7 +26,7 @@
 <div class="titlepage"><div><div><h2 class="title" style="clear: both">
 <a name="boost_config.rationale"></a><a class="link" href="rationale.html" title="Rationale">Rationale</a>
 </h2></div></div></div>
-<div class="toc"><dl>
+<div class="toc"><dl class="toc">
 <dt><span class="section"><a href="rationale.html#boost_config.rationale.the_problem">The problem</a></span></dt>
 <dt><span class="section"><a href="rationale.html#boost_config.rationale.the_solution">The solution</a></span></dt>
 </dl></div>

--- a/doc/html/index.html
+++ b/doc/html/index.html
@@ -3,7 +3,7 @@
 <meta http-equiv="Content-Type" content="text/html; charset=US-ASCII">
 <title>Boost.Config</title>
 <link rel="stylesheet" href="../../../../doc/src/boostbook.css" type="text/css">
-<meta name="generator" content="DocBook XSL Stylesheets V1.77.1">
+<meta name="generator" content="DocBook XSL Stylesheets V1.79.1">
 <link rel="home" href="index.html" title="Boost.Config">
 <link rel="next" href="boost_config/boost_macro_reference.html" title="Boost Macro Reference">
 </head>
@@ -39,7 +39,7 @@
 </div>
 <div class="toc">
 <p><b>Table of Contents</b></p>
-<dl>
+<dl class="toc">
 <dt><span class="section"><a href="index.html#boost_config.configuring_boost_for_your_platform">Configuring
     Boost for Your Platform</a></span></dt>
 <dd><dl>
@@ -127,7 +127,7 @@
 <a name="boost_config.configuring_boost_for_your_platform"></a><a class="link" href="index.html#boost_config.configuring_boost_for_your_platform" title="Configuring Boost for Your Platform">Configuring
     Boost for Your Platform</a>
 </h2></div></div></div>
-<div class="toc"><dl>
+<div class="toc"><dl class="toc">
 <dt><span class="section"><a href="index.html#boost_config.configuring_boost_for_your_platform.using_the_default_boost_configuration">Using
       the default boost configuration</a></span></dt>
 <dt><span class="section"><a href="index.html#boost_config.configuring_boost_for_your_platform.the__boost_config_hpp__header">The
@@ -725,7 +725,7 @@
 <a name="boost_config.configuring_boost_for_your_platform.advanced_configuration_usage"></a><a class="link" href="index.html#boost_config.configuring_boost_for_your_platform.advanced_configuration_usage" title="Advanced configuration usage">Advanced
       configuration usage</a>
 </h3></div></div></div>
-<div class="toc"><dl>
+<div class="toc"><dl class="toc">
 <dt><span class="section"><a href="index.html#boost_config.configuring_boost_for_your_platform.advanced_configuration_usage.example_1__creating_our_own_frozen_configuration">Example
         1: creating our own frozen configuration</a></span></dt>
 <dt><span class="section"><a href="index.html#boost_config.configuring_boost_for_your_platform.advanced_configuration_usage.example_2__skipping_files_that_you_don_t_need">Example
@@ -757,7 +757,7 @@
         user settable macros</a>).
       </p>
 <p>
-        Finally the boost configuration header, includes <a href="../../../../boost/config/user.hpp" target="_top">&lt;boost/config/suffix.hpp&gt;</a>;
+        Finally the boost configuration header, includes <a href="../../../../boost/config/detail/suffix.hpp" target="_top">&lt;boost/config/detail/suffix.hpp&gt;</a>;
         this header contains any boiler plate configuration code - for example where
         one boost macro being set implies that another must be set also.
       </p>
@@ -992,7 +992,7 @@
 </div>
 </div>
 <table xmlns:rev="http://www.cs.rpi.edu/~gregod/boost/tools/doc/revision" width="100%"><tr>
-<td align="left"><p><small>Last revised: April 17, 2017 at 17:42:09 GMT</small></p></td>
+<td align="left"><p><small>Last revised: July 12, 2017 at 17:44:55 GMT</small></p></td>
 <td align="right"><div class="copyright-footer"></div></td>
 </tr></table>
 <hr>


### PR DESCRIPTION
A few headers were moved to `boost/config/detail`. This PR updates the docs accordingly.
