### PR TITLE
Fix bash paths in shebangs

### DIFF
--- a/test/link/bc_gen.sh
+++ b/test/link/bc_gen.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#! /usr/bin/env bash
 
 # copyright John Maddock 2005
 # Use, modification and distribution are subject to the 

--- a/test/link/vc_gen.sh
+++ b/test/link/vc_gen.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#! /usr/bin/env bash
 # copyright John Maddock 2005
 # Use, modification and distribution are subject to the 
 # Boost Software License, Version 1.0. (See accompanying file 


### PR DESCRIPTION
"/bin/bash" is a Linuxism.  "/usr/bin/env bash" is portable.