### PR TITLE
Update PGI C++ compiler support

### DIFF
--- a/include/boost/cstdint.hpp
+++ b/include/boost/cstdint.hpp
@@ -367,9 +367,6 @@ namespace boost
 #include <stddef.h>
 #endif
 
-// PGI seems to not support intptr_t/uintptr_t properly. BOOST_HAS_STDINT_H is not defined for this compiler by Boost.Config.
-#if !defined(__PGIC__)
-
 #if (defined(BOOST_WINDOWS) && !defined(_WIN32_WCE)) \
     || (defined(_XOPEN_UNIX) && (_XOPEN_UNIX+0 > 0) && !defined(__UCLIBC__)) \
     || defined(__CYGWIN__) \
@@ -392,8 +389,6 @@ namespace boost {
 #define BOOST_HAS_INTPTR_T
 
 #endif
-
-#endif // !defined(__PGIC__)
 
 #endif // BOOST_CSTDINT_HPP
 


### PR DESCRIPTION
Remove an old PGI-specific workaround for intptr_t.  The workaround is no longer necessary and now causes compilation errors.