### PR TITLE
Incorrect MSVC version detection

### DIFF
--- a/include/boost/config/compiler/visualc.hpp
+++ b/include/boost/config/compiler/visualc.hpp
@@ -289,7 +289,7 @@
 #      endif
 #   endif
 # else
-#   if _MSC_VER < 1310
+#   if _MSC_VER < 1200
       // Note: Versions up to 7.0 aren't supported.
 #     define BOOST_COMPILER_VERSION 5.0
 #   elif _MSC_VER < 1300


### PR DESCRIPTION
I know, Boost doesn't support MSVC 5.0 and 6.0. But the expression is invalid. Another way to fix it is
```c++
#   if _MSC_VER < 1300
      // Note: Versions up to 7.0 aren't supported.
#     define BOOST_COMPILER_VERSION 6.0
#   elif _MSC_VER < 1310
#     define BOOST_COMPILER_VERSION 7.0
```