### PR TITLE
Add BOOST_PRAGMA_MESSAGE

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,16 +6,11 @@ language: cpp
 
 sudo: false
 
-python: "2.7"
-
-os:
-  - linux
-  - osx
-
 branches:
   only:
     - master
     - develop
+    - /feature\/.*/
 
 env:
   matrix:
@@ -58,7 +53,7 @@ matrix:
             - ubuntu-toolchain-r-test
 
     - os: linux
-      env: TOOLSET=gcc COMPILER=g++-5 CXXSTD=03,11,14
+      env: TOOLSET=gcc COMPILER=g++-5 CXXSTD=03,11,14,1z
       addons:
         apt:
           packages:
@@ -85,10 +80,19 @@ matrix:
             - ubuntu-toolchain-r-test
 
     - os: linux
+      env: TOOLSET=gcc COMPILER=g++-7 CXXSTD=03,11,14,17
+      addons:
+        apt:
+          packages:
+            - g++-7
+          sources:
+            - ubuntu-toolchain-r-test
+
+    - os: linux
       env: TOOLSET=clang COMPILER=clang++ CXXSTD=03,11
 
     - os: linux
-      env: TOOLSET=clang COMPILER=clang++-3.5 CXXSTD=03,11
+      env: TOOLSET=clang COMPILER=clang++-3.5 CXXSTD=03,11,14,1z
       addons:
         apt:
           packages:
@@ -98,7 +102,7 @@ matrix:
             - llvm-toolchain-precise-3.5
 
     - os: linux
-      env: TOOLSET=clang COMPILER=clang++-3.6 CXXSTD=03,11
+      env: TOOLSET=clang COMPILER=clang++-3.6 CXXSTD=03,11,14,1z
       addons:
         apt:
           packages:
@@ -108,7 +112,7 @@ matrix:
             - llvm-toolchain-precise-3.6
 
     - os: linux
-      env: TOOLSET=clang COMPILER=clang++-3.7 CXXSTD=03,11
+      env: TOOLSET=clang COMPILER=clang++-3.7 CXXSTD=03,11,14,1z
       addons:
         apt:
           packages:
@@ -137,21 +141,43 @@ matrix:
             - ubuntu-toolchain-r-test
             - llvm-toolchain-precise-3.9
 
+    - os: linux
+      compiler: clang++-4.0
+      env: TOOLSET=clang COMPILER=clang++-4.0 CXXSTD=03,11,14,1z
+      addons:
+        apt:
+          packages:
+            - clang-4.0
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-trusty-4.0
+
+    - os: linux
+      compiler: clang++-5.0
+      env: TOOLSET=clang COMPILER=clang++-5.0 CXXSTD=03,11,14,1z
+      addons:
+        apt:
+          packages:
+            - clang-5.0
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-trusty-5.0
+
+    - os: osx
+      env: TOOLSET=clang COMPILER=clang++ CXXSTD=03,11,14,1z
+      osx_image: xcode9.1
+
+    - os: osx
+      env: TOOLSET=clang COMPILER=clang++ CXXSTD=03,11,14,1z
+      osx_image: xcode9
+
     - os: osx
       env: TOOLSET=clang COMPILER=clang++ CXXSTD=03,11,14,1z
       osx_image: xcode8.3
 
     - os: osx
       env: TOOLSET=clang COMPILER=clang++ CXXSTD=03,11,14,1z
-      osx_image: xcode8.2
-
-    - os: osx
-      env: TOOLSET=clang COMPILER=clang++ CXXSTD=03,11,14,1z
-      osx_image: xcode8.1
-
-    - os: osx
-      env: TOOLSET=clang COMPILER=clang++ CXXSTD=03,11,14,1z
-      osx_image: xcode8.0
+      osx_image: xcode8
 
     - os: osx
       env: TOOLSET=clang COMPILER=clang++ CXXSTD=03,11,14,1z
@@ -162,8 +188,9 @@ matrix:
       osx_image: xcode6.4
 
 install:
+  - BOOST_BRANCH=develop && [ "$TRAVIS_BRANCH" == "master" ] && BOOST_BRANCH=master || true
   - cd ..
-  - git clone -b $TRAVIS_BRANCH --depth 1 https://github.com/boostorg/boost.git boost-root
+  - git clone -b $BOOST_BRANCH --depth 1 https://github.com/boostorg/boost.git boost-root
   - cd boost-root
   - git submodule update --init tools/build
   - git submodule update --init libs/detail

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
 
   include:
     - os: linux
-      env: TOOLSET=gcc COMPILER=g++ CXXSTD=03
+      env: TOOLSET=gcc COMPILER=g++ CXXSTD=03,11
 
     - os: linux
       env: TOOLSET=gcc COMPILER=g++-4.7 CXXSTD=03,11

--- a/doc/html/boost_config/acknowledgements.html
+++ b/doc/html/boost_config/acknowledgements.html
@@ -3,7 +3,7 @@
 <meta http-equiv="Content-Type" content="text/html; charset=US-ASCII">
 <title>Acknowledgements</title>
 <link rel="stylesheet" href="../../../../../doc/src/boostbook.css" type="text/css">
-<meta name="generator" content="DocBook XSL Stylesheets V1.77.1">
+<meta name="generator" content="DocBook XSL Stylesheets V1.78.1">
 <link rel="home" href="../index.html" title="Boost.Config">
 <link rel="up" href="../index.html" title="Boost.Config">
 <link rel="prev" href="rationale.html" title="Rationale">

--- a/doc/html/boost_config/boost_macro_reference.html
+++ b/doc/html/boost_config/boost_macro_reference.html
@@ -3968,7 +3968,7 @@
                   that is not otherwise described by one of the other Boost.Config
                   macros. To use the macro you must first
 </p>
-<pre xmlns:rev="http://www.cs.rpi.edu/~gregod/boost/tools/doc/revision" class="table-programlisting"><span class="preprocessor">#include</span> <span class="special">&lt;</span><span class="identifier">boost</span><span class="special">/</span><span class="identifier">detail</span><span class="special">/</span><span class="identifier">workaround</span><span class="special">.</span><span class="identifier">hpp</span><span class="special">&gt;</span>
+<pre xmlns:rev="http://www.cs.rpi.edu/~gregod/boost/tools/doc/revision" class="table-programlisting"><span class="preprocessor">#include</span> <span class="special">&lt;</span><span class="identifier">boost</span><span class="special">/</span><span class="identifier">config</span><span class="special">/</span><span class="identifier">workaround</span><span class="special">.</span><span class="identifier">hpp</span><span class="special">&gt;</span>
 </pre>
 <p>
                   usage is then:
@@ -3999,7 +3999,7 @@
                 </p>
                 <p>
                   <span class="bold"><strong>Note</strong></span>: the ultimate source of documentation
-                  for this macro is in <a href="../../../../../boost/detail/workaround.hpp" target="_top">boost/detail/workaround.hpp</a>.
+                  for this macro is in <a href="../../../../../boost/config/workaround.hpp" target="_top">boost/config/workaround.hpp</a>.
                 </p>
               </td>
 </tr>
@@ -4551,7 +4551,8 @@
               </td>
 <td>
                 <p>
-                  Expands to the equivalent of <code class="computeroutput"><span class="preprocessor">#pragma</span>
+                  Defined in header <code class="computeroutput"><span class="special">&lt;</span><span class="identifier">boost</span><span class="special">/</span><span class="identifier">config</span><span class="special">/</span><span class="identifier">pragma_message</span><span class="special">.</span><span class="identifier">hpp</span><span class="special">&gt;</span></code>,
+                  this macro expands to the equivalent of <code class="computeroutput"><span class="preprocessor">#pragma</span>
                   <span class="identifier">message</span><span class="special">(</span><span class="identifier">M</span><span class="special">)</span></code>.
                   <code class="computeroutput"><span class="identifier">M</span></code> must be a string
                   literal. Example: <code class="computeroutput"><span class="identifier">BOOST_PRAGMA_MESSAGE</span><span class="special">(</span><span class="string">"This header

--- a/doc/html/boost_config/boost_macro_reference.html
+++ b/doc/html/boost_config/boost_macro_reference.html
@@ -3,7 +3,7 @@
 <meta http-equiv="Content-Type" content="text/html; charset=US-ASCII">
 <title>Boost Macro Reference</title>
 <link rel="stylesheet" href="../../../../../doc/src/boostbook.css" type="text/css">
-<meta name="generator" content="DocBook XSL Stylesheets V1.77.1">
+<meta name="generator" content="DocBook XSL Stylesheets V1.78.1">
 <link rel="home" href="../index.html" title="Boost.Config">
 <link rel="up" href="../index.html" title="Boost.Config">
 <link rel="prev" href="../index.html" title="Boost.Config">
@@ -26,7 +26,7 @@
 <div class="titlepage"><div><div><h2 class="title" style="clear: both">
 <a name="boost_config.boost_macro_reference"></a><a class="link" href="boost_macro_reference.html" title="Boost Macro Reference">Boost Macro Reference</a>
 </h2></div></div></div>
-<div class="toc"><dl>
+<div class="toc"><dl class="toc">
 <dt><span class="section"><a href="boost_macro_reference.html#boost_config.boost_macro_reference.macros_that_describe_c__03_defects">Macros
       that describe C++03 defects</a></span></dt>
 <dt><span class="section"><a href="boost_macro_reference.html#boost_config.boost_macro_reference.macros_that_describe_optional_features">Macros
@@ -3829,6 +3829,18 @@
                 </p>
               </td>
 </tr>
+<tr>
+<td>
+                <p>
+                  <code class="computeroutput"><span class="identifier">BOOST_NO_CXX17_ITERATOR_TRAITS</span></code>
+                </p>
+              </td>
+<td>
+                <p>
+                  The compiler does not support SFINAE-friendly <code class="computeroutput"><span class="identifier">std</span><span class="special">::</span><span class="identifier">iterator_traits</span></code>.
+                </p>
+              </td>
+</tr>
 </tbody>
 </table></div>
 </div>
@@ -4183,7 +4195,16 @@
 <tr>
 <td>
                 <p>
-                  <code class="computeroutput"><span class="identifier">BOOST_EXPLICIT_TEMPLATE_TYPE</span><span class="special">(</span><span class="identifier">t</span><span class="special">)</span></code> <code class="computeroutput"><span class="identifier">BOOST_EXPLICIT_TEMPLATE_NON_TYPE</span><span class="special">(</span><span class="identifier">t</span><span class="special">,</span><span class="identifier">v</span><span class="special">)</span></code> <code class="computeroutput"><span class="identifier">BOOST_APPEND_EXPLICIT_TEMPLATE_TYPE</span><span class="special">(</span><span class="identifier">t</span><span class="special">)</span></code> <code class="computeroutput"><span class="identifier">BOOST_APPEND_EXPLICIT_TEMPLATE_NON_TYPE</span><span class="special">(</span><span class="identifier">t</span><span class="special">,</span><span class="identifier">v</span><span class="special">)</span></code>
+                  <code class="computeroutput"><span class="identifier">BOOST_EXPLICIT_TEMPLATE_TYPE</span><span class="special">(</span><span class="identifier">t</span><span class="special">)</span></code>
+                </p>
+                <p>
+                  <code class="computeroutput"><span class="identifier">BOOST_EXPLICIT_TEMPLATE_NON_TYPE</span><span class="special">(</span><span class="identifier">t</span><span class="special">,</span><span class="identifier">v</span><span class="special">)</span></code>
+                </p>
+                <p>
+                  <code class="computeroutput"><span class="identifier">BOOST_APPEND_EXPLICIT_TEMPLATE_TYPE</span><span class="special">(</span><span class="identifier">t</span><span class="special">)</span></code>
+                </p>
+                <p>
+                  <code class="computeroutput"><span class="identifier">BOOST_APPEND_EXPLICIT_TEMPLATE_NON_TYPE</span><span class="special">(</span><span class="identifier">t</span><span class="special">,</span><span class="identifier">v</span><span class="special">)</span></code>
                 </p>
               </td>
 <td>
@@ -4452,6 +4473,8 @@
 <td>
                 <p>
                   <code class="computeroutput"><span class="identifier">BOOST_LIKELY</span><span class="special">(</span><span class="identifier">X</span><span class="special">)</span></code>
+                </p>
+                <p>
                   <code class="computeroutput"><span class="identifier">BOOST_UNLIKELY</span><span class="special">(</span><span class="identifier">X</span><span class="special">)</span></code>
                 </p>
               </td>
@@ -4517,6 +4540,22 @@
 <span class="keyword">typedef</span> <span class="keyword">unsigned</span> <span class="keyword">int</span> <span class="identifier">BOOST_MAY_ALIAS</span> <span class="identifier">aliasing_uint</span><span class="special">;</span>
 </pre>
 <p>
+                </p>
+              </td>
+</tr>
+<tr>
+<td>
+                <p>
+                  <code class="computeroutput"><span class="identifier">BOOST_PRAGMA_MESSAGE</span><span class="special">(</span><span class="identifier">M</span><span class="special">)</span></code>
+                </p>
+              </td>
+<td>
+                <p>
+                  Expands to the equivalent of <code class="computeroutput"><span class="preprocessor">#pragma</span>
+                  <span class="identifier">message</span><span class="special">(</span><span class="identifier">M</span><span class="special">)</span></code>.
+                  <code class="computeroutput"><span class="identifier">M</span></code> must be a string
+                  literal. Example: <code class="computeroutput"><span class="identifier">BOOST_PRAGMA_MESSAGE</span><span class="special">(</span><span class="string">"This header
+                  is deprecated."</span><span class="special">)</span></code>.
                 </p>
               </td>
 </tr>
@@ -5884,7 +5923,7 @@
 <a name="boost_config.boost_macro_reference.macros_for_libraries_with_separate_source_code"></a><a class="link" href="boost_macro_reference.html#boost_config.boost_macro_reference.macros_for_libraries_with_separate_source_code" title="Macros for libraries with separate source code">Macros
       for libraries with separate source code</a>
 </h3></div></div></div>
-<div class="toc"><dl>
+<div class="toc"><dl class="toc">
 <dt><span class="section"><a href="boost_macro_reference.html#boost_config.boost_macro_reference.macros_for_libraries_with_separate_source_code.macros_controlling_shared_library_symbol_visibility">Macros
         controlling shared library symbol visibility</a></span></dt>
 <dt><span class="section"><a href="boost_macro_reference.html#boost_config.boost_macro_reference.macros_for_libraries_with_separate_source_code.abi_fixing">ABI

--- a/doc/html/boost_config/build_config.html
+++ b/doc/html/boost_config/build_config.html
@@ -3,7 +3,7 @@
 <meta http-equiv="Content-Type" content="text/html; charset=US-ASCII">
 <title>Build Time Configuration</title>
 <link rel="stylesheet" href="../../../../../doc/src/boostbook.css" type="text/css">
-<meta name="generator" content="DocBook XSL Stylesheets V1.77.1">
+<meta name="generator" content="DocBook XSL Stylesheets V1.78.1">
 <link rel="home" href="../index.html" title="Boost.Config">
 <link rel="up" href="../index.html" title="Boost.Config">
 <link rel="prev" href="boost_macro_reference.html" title="Boost Macro Reference">

--- a/doc/html/boost_config/cstdint.html
+++ b/doc/html/boost_config/cstdint.html
@@ -3,7 +3,7 @@
 <meta http-equiv="Content-Type" content="text/html; charset=US-ASCII">
 <title>Standard Integer Types</title>
 <link rel="stylesheet" href="../../../../../doc/src/boostbook.css" type="text/css">
-<meta name="generator" content="DocBook XSL Stylesheets V1.77.1">
+<meta name="generator" content="DocBook XSL Stylesheets V1.78.1">
 <link rel="home" href="../index.html" title="Boost.Config">
 <link rel="up" href="../index.html" title="Boost.Config">
 <link rel="prev" href="build_config.html" title="Build Time Configuration">
@@ -26,7 +26,7 @@
 <div class="titlepage"><div><div><h2 class="title" style="clear: both">
 <a name="boost_config.cstdint"></a><a class="link" href="cstdint.html" title="Standard Integer Types">Standard Integer Types</a>
 </h2></div></div></div>
-<div class="toc"><dl>
+<div class="toc"><dl class="toc">
 <dt><span class="section"><a href="cstdint.html#boost_config.cstdint.overview">Overview</a></span></dt>
 <dt><span class="section"><a href="cstdint.html#boost_config.cstdint.rationale">Rationale</a></span></dt>
 <dt><span class="section"><a href="cstdint.html#boost_config.cstdint.ce"><span class="emphasis"><em>Caveat emptor</em></span></a></span></dt>

--- a/doc/html/boost_config/guidelines_for_boost_authors.html
+++ b/doc/html/boost_config/guidelines_for_boost_authors.html
@@ -3,7 +3,7 @@
 <meta http-equiv="Content-Type" content="text/html; charset=US-ASCII">
 <title>Guidelines for Boost Authors</title>
 <link rel="stylesheet" href="../../../../../doc/src/boostbook.css" type="text/css">
-<meta name="generator" content="DocBook XSL Stylesheets V1.77.1">
+<meta name="generator" content="DocBook XSL Stylesheets V1.78.1">
 <link rel="home" href="../index.html" title="Boost.Config">
 <link rel="up" href="../index.html" title="Boost.Config">
 <link rel="prev" href="cstdint.html" title="Standard Integer Types">
@@ -27,7 +27,7 @@
 <a name="boost_config.guidelines_for_boost_authors"></a><a class="link" href="guidelines_for_boost_authors.html" title="Guidelines for Boost Authors">Guidelines for
     Boost Authors</a>
 </h2></div></div></div>
-<div class="toc"><dl>
+<div class="toc"><dl class="toc">
 <dt><span class="section"><a href="guidelines_for_boost_authors.html#boost_config.guidelines_for_boost_authors.warnings">Disabling
       Compiler Warnings</a></span></dt>
 <dt><span class="section"><a href="guidelines_for_boost_authors.html#boost_config.guidelines_for_boost_authors.adding_new_defect_macros">Adding

--- a/doc/html/boost_config/rationale.html
+++ b/doc/html/boost_config/rationale.html
@@ -3,7 +3,7 @@
 <meta http-equiv="Content-Type" content="text/html; charset=US-ASCII">
 <title>Rationale</title>
 <link rel="stylesheet" href="../../../../../doc/src/boostbook.css" type="text/css">
-<meta name="generator" content="DocBook XSL Stylesheets V1.77.1">
+<meta name="generator" content="DocBook XSL Stylesheets V1.78.1">
 <link rel="home" href="../index.html" title="Boost.Config">
 <link rel="up" href="../index.html" title="Boost.Config">
 <link rel="prev" href="guidelines_for_boost_authors.html" title="Guidelines for Boost Authors">
@@ -26,7 +26,7 @@
 <div class="titlepage"><div><div><h2 class="title" style="clear: both">
 <a name="boost_config.rationale"></a><a class="link" href="rationale.html" title="Rationale">Rationale</a>
 </h2></div></div></div>
-<div class="toc"><dl>
+<div class="toc"><dl class="toc">
 <dt><span class="section"><a href="rationale.html#boost_config.rationale.the_problem">The problem</a></span></dt>
 <dt><span class="section"><a href="rationale.html#boost_config.rationale.the_solution">The solution</a></span></dt>
 </dl></div>

--- a/doc/html/index.html
+++ b/doc/html/index.html
@@ -992,7 +992,7 @@
 </div>
 </div>
 <table xmlns:rev="http://www.cs.rpi.edu/~gregod/boost/tools/doc/revision" width="100%"><tr>
-<td align="left"><p><small>Last revised: December 03, 2017 at 22:51:50 GMT</small></p></td>
+<td align="left"><p><small>Last revised: December 03, 2017 at 23:12:48 GMT</small></p></td>
 <td align="right"><div class="copyright-footer"></div></td>
 </tr></table>
 <hr>

--- a/doc/html/index.html
+++ b/doc/html/index.html
@@ -3,7 +3,7 @@
 <meta http-equiv="Content-Type" content="text/html; charset=US-ASCII">
 <title>Boost.Config</title>
 <link rel="stylesheet" href="../../../../doc/src/boostbook.css" type="text/css">
-<meta name="generator" content="DocBook XSL Stylesheets V1.77.1">
+<meta name="generator" content="DocBook XSL Stylesheets V1.78.1">
 <link rel="home" href="index.html" title="Boost.Config">
 <link rel="next" href="boost_config/boost_macro_reference.html" title="Boost Macro Reference">
 </head>
@@ -39,7 +39,7 @@
 </div>
 <div class="toc">
 <p><b>Table of Contents</b></p>
-<dl>
+<dl class="toc">
 <dt><span class="section"><a href="index.html#boost_config.configuring_boost_for_your_platform">Configuring
     Boost for Your Platform</a></span></dt>
 <dd><dl>
@@ -127,7 +127,7 @@
 <a name="boost_config.configuring_boost_for_your_platform"></a><a class="link" href="index.html#boost_config.configuring_boost_for_your_platform" title="Configuring Boost for Your Platform">Configuring
     Boost for Your Platform</a>
 </h2></div></div></div>
-<div class="toc"><dl>
+<div class="toc"><dl class="toc">
 <dt><span class="section"><a href="index.html#boost_config.configuring_boost_for_your_platform.using_the_default_boost_configuration">Using
       the default boost configuration</a></span></dt>
 <dt><span class="section"><a href="index.html#boost_config.configuring_boost_for_your_platform.the__boost_config_hpp__header">The
@@ -725,7 +725,7 @@
 <a name="boost_config.configuring_boost_for_your_platform.advanced_configuration_usage"></a><a class="link" href="index.html#boost_config.configuring_boost_for_your_platform.advanced_configuration_usage" title="Advanced configuration usage">Advanced
       configuration usage</a>
 </h3></div></div></div>
-<div class="toc"><dl>
+<div class="toc"><dl class="toc">
 <dt><span class="section"><a href="index.html#boost_config.configuring_boost_for_your_platform.advanced_configuration_usage.example_1__creating_our_own_frozen_configuration">Example
         1: creating our own frozen configuration</a></span></dt>
 <dt><span class="section"><a href="index.html#boost_config.configuring_boost_for_your_platform.advanced_configuration_usage.example_2__skipping_files_that_you_don_t_need">Example
@@ -992,7 +992,7 @@
 </div>
 </div>
 <table xmlns:rev="http://www.cs.rpi.edu/~gregod/boost/tools/doc/revision" width="100%"><tr>
-<td align="left"><p><small>Last revised: July 21, 2017 at 18:08:20 GMT</small></p></td>
+<td align="left"><p><small>Last revised: December 03, 2017 at 22:51:50 GMT</small></p></td>
 <td align="right"><div class="copyright-footer"></div></td>
 </tr></table>
 <hr>

--- a/doc/macro_reference.qbk
+++ b/doc/macro_reference.qbk
@@ -979,7 +979,7 @@ workarounds for compiler/standard library defects.
 This macro is used where a compiler specific workaround is required that is not otherwise
 described by one of the other Boost.Config macros.  To use the macro you must first
 ``
-#include <boost/detail/workaround.hpp>
+#include <boost/config/workaround.hpp>
 ``
 usage is then:
 ``
@@ -1001,7 +1001,7 @@ For example
 of `__BORLANDC__` /unless/ the macro `BOOST_DETECT_OUTDATED_WORKAROUNDS` is defined, in which case evaluates to
 `(__BORLANDC__ <= 0x590)`.
 
-[*Note]: the ultimate source of documentation for this macro is in [@../../../../boost/detail/workaround.hpp boost/detail/workaround.hpp].
+[*Note]: the ultimate source of documentation for this macro is in [@../../../../boost/config/workaround.hpp boost/config/workaround.hpp].
 ]]
 [[`BOOST_PREVENT_MACRO_SUBSTITUTION`][
 Sometimes you have a function name with the same name as a C macro, for example "min" and "max"
@@ -1279,8 +1279,9 @@ Usage example:
   typedef unsigned int BOOST_MAY_ALIAS aliasing_uint;
 ``
 ]]
-[[`BOOST_PRAGMA_MESSAGE(M)`][Expands to the equivalent of `#pragma message(M)`. `M` must
-be a string literal. Example: `BOOST_PRAGMA_MESSAGE("This header is deprecated.")`.]]
+[[`BOOST_PRAGMA_MESSAGE(M)`][Defined in header `<boost/config/pragma_message.hpp>`,
+this macro expands to the equivalent of `#pragma message(M)`. `M` must be a string
+literal. Example: `BOOST_PRAGMA_MESSAGE("This header is deprecated.")`.]]
 ]
 
 [endsect]

--- a/doc/macro_reference.qbk
+++ b/doc/macro_reference.qbk
@@ -1095,8 +1095,11 @@ In either case this macro has no effect on runtime behavior and performance
 of code. 
 ]] 
 [[`BOOST_EXPLICIT_TEMPLATE_TYPE(t)`
+
   `BOOST_EXPLICIT_TEMPLATE_NON_TYPE(t,v)`
+
   `BOOST_APPEND_EXPLICIT_TEMPLATE_TYPE(t)`
+
   `BOOST_APPEND_EXPLICIT_TEMPLATE_NON_TYPE(t,v)`][
 Some compilers silently "fold" different function template instantiations if
 some of the template parameters don't appear in the function parameter list.
@@ -1247,6 +1250,7 @@ If the compiler does not support this markup, `BOOST_NORETURN` is defined empty 
 additional macro `BOOST_NO_NORETURN` is defined.
 ]]
 [[`BOOST_LIKELY(X)`
+
   `BOOST_UNLIKELY(X)`][
 These macros communicate to the compiler that the conditional expression `X` is likely
 or unlikely to yield a positive result. The expression should result in a boolean value.
@@ -1275,6 +1279,8 @@ Usage example:
   typedef unsigned int BOOST_MAY_ALIAS aliasing_uint;
 ``
 ]]
+[[`BOOST_PRAGMA_MESSAGE(M)`][Expands to the equivalent of `#pragma message(M)`. `M` must
+be a string literal. Example: `BOOST_PRAGMA_MESSAGE("This header is deprecated.")`.]]
 ]
 
 [endsect]

--- a/include/boost/config/detail/suffix.hpp
+++ b/include/boost/config/detail/suffix.hpp
@@ -537,25 +537,10 @@ namespace std{ using ::type_info; }
 
 // ---------------------------------------------------------------------------//
 
-//
 // Helper macro BOOST_STRINGIZE:
-// Converts the parameter X to a string after macro replacement
-// on X has been performed.
-//
-#define BOOST_STRINGIZE(X) BOOST_DO_STRINGIZE(X)
-#define BOOST_DO_STRINGIZE(X) #X
-
-//
 // Helper macro BOOST_JOIN:
-// The following piece of macro magic joins the two
-// arguments together, even when one of the arguments is
-// itself a macro (see 16.3.1 in C++ standard).  The key
-// is that macro expansion of macro arguments does not
-// occur in BOOST_DO_JOIN2 but does in BOOST_DO_JOIN.
-//
-#define BOOST_JOIN( X, Y ) BOOST_DO_JOIN( X, Y )
-#define BOOST_DO_JOIN( X, Y ) BOOST_DO_JOIN2(X,Y)
-#define BOOST_DO_JOIN2( X, Y ) X##Y
+
+#include <boost/config/helper_macros.hpp>
 
 //
 // Set some default values for compiler/library/platform names.

--- a/include/boost/config/helper_macros.hpp
+++ b/include/boost/config/helper_macros.hpp
@@ -1,0 +1,37 @@
+#ifndef BOOST_CONFIG_HELPER_MACROS_HPP_INCLUDED
+#define BOOST_CONFIG_HELPER_MACROS_HPP_INCLUDED
+
+//  Copyright 2001 John Maddock.
+//  Copyright 2017 Peter Dimov.
+//
+//  Distributed under the Boost Software License, Version 1.0.
+//
+//  See accompanying file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt
+//
+//  BOOST_STRINGIZE(X)
+//  BOOST_JOIN(X, Y)
+//
+//  Note that this header is C compatible.
+
+//
+// Helper macro BOOST_STRINGIZE:
+// Converts the parameter X to a string after macro replacement
+// on X has been performed.
+//
+#define BOOST_STRINGIZE(X) BOOST_DO_STRINGIZE(X)
+#define BOOST_DO_STRINGIZE(X) #X
+
+//
+// Helper macro BOOST_JOIN:
+// The following piece of macro magic joins the two
+// arguments together, even when one of the arguments is
+// itself a macro (see 16.3.1 in C++ standard).  The key
+// is that macro expansion of macro arguments does not
+// occur in BOOST_DO_JOIN2 but does in BOOST_DO_JOIN.
+//
+#define BOOST_JOIN(X, Y) BOOST_DO_JOIN(X, Y)
+#define BOOST_DO_JOIN(X, Y) BOOST_DO_JOIN2(X,Y)
+#define BOOST_DO_JOIN2(X, Y) X##Y
+
+#endif // BOOST_CONFIG_HELPER_MACROS_HPP_INCLUDED

--- a/include/boost/config/pragma_message.hpp
+++ b/include/boost/config/pragma_message.hpp
@@ -1,0 +1,24 @@
+#ifndef BOOST_CONFIG_PRAGMA_MESSAGE_HPP_INCLUDED
+#define BOOST_CONFIG_PRAGMA_MESSAGE_HPP_INCLUDED
+
+//  Copyright 2017 Peter Dimov.
+//
+//  Distributed under the Boost Software License, Version 1.0.
+//
+//  See accompanying file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt
+//
+//  BOOST_PRAGMA_MESSAGE("message")
+
+#if defined(__GNUC__)
+#define BOOST_PRAGMA_MESSAGE_IMPL_1(x) _Pragma(#x)
+#define BOOST_PRAGMA_MESSAGE(x) BOOST_PRAGMA_MESSAGE_IMPL_1(message(x))
+#elif defined(_MSC_VER)
+#define BOOST_PRAGMA_MESSAGE_IMPL_2(x, f, ln) __pragma(message(f "(" #ln "): note: " x))
+#define BOOST_PRAGMA_MESSAGE_IMPL_1(x, f, ln) BOOST_PRAGMA_MESSAGE_IMPL_2(x, f, ln)
+#define BOOST_PRAGMA_MESSAGE(x) BOOST_PRAGMA_MESSAGE_IMPL_1(x, __FILE__, __LINE__)
+#else
+#define BOOST_PRAGMA_MESSAGE(x)
+#endif
+
+#endif // BOOST_CONFIG_PRAGMA_MESSAGE_HPP_INCLUDED

--- a/include/boost/config/pragma_message.hpp
+++ b/include/boost/config/pragma_message.hpp
@@ -16,12 +16,14 @@
 
 #include <boost/config/helper_macros.hpp>
 
-#if defined(__GNUC__)
-#define BOOST_PRAGMA_MESSAGE(x) _Pragma(BOOST_STRINGIZE(message(x)))
+#if defined(BOOST_DISABLE_PRAGMA_MESSAGE)
+# define BOOST_PRAGMA_MESSAGE(x)
+#elif defined(__GNUC__)
+# define BOOST_PRAGMA_MESSAGE(x) _Pragma(BOOST_STRINGIZE(message(x)))
 #elif defined(_MSC_VER)
-#define BOOST_PRAGMA_MESSAGE(x) __pragma(message(__FILE__ "(" BOOST_STRINGIZE(__LINE__) "): note: " x))
+# define BOOST_PRAGMA_MESSAGE(x) __pragma(message(__FILE__ "(" BOOST_STRINGIZE(__LINE__) "): note: " x))
 #else
-#define BOOST_PRAGMA_MESSAGE(x)
+# define BOOST_PRAGMA_MESSAGE(x)
 #endif
 
 #endif // BOOST_CONFIG_PRAGMA_MESSAGE_HPP_INCLUDED

--- a/include/boost/config/pragma_message.hpp
+++ b/include/boost/config/pragma_message.hpp
@@ -9,14 +9,17 @@
 //  http://www.boost.org/LICENSE_1_0.txt
 //
 //  BOOST_PRAGMA_MESSAGE("message")
+//
+//  Expands to the equivalent of #pragma message("message")
+//
+//  Note that this header is C compatible.
+
+#include <boost/config/helper_macros.hpp>
 
 #if defined(__GNUC__)
-#define BOOST_PRAGMA_MESSAGE_IMPL_1(x) _Pragma(#x)
-#define BOOST_PRAGMA_MESSAGE(x) BOOST_PRAGMA_MESSAGE_IMPL_1(message(x))
+#define BOOST_PRAGMA_MESSAGE(x) _Pragma(BOOST_STRINGIZE(message(x)))
 #elif defined(_MSC_VER)
-#define BOOST_PRAGMA_MESSAGE_IMPL_2(x, f, ln) __pragma(message(f "(" #ln "): note: " x))
-#define BOOST_PRAGMA_MESSAGE_IMPL_1(x, f, ln) BOOST_PRAGMA_MESSAGE_IMPL_2(x, f, ln)
-#define BOOST_PRAGMA_MESSAGE(x) BOOST_PRAGMA_MESSAGE_IMPL_1(x, __FILE__, __LINE__)
+#define BOOST_PRAGMA_MESSAGE(x) __pragma(message(__FILE__ "(" BOOST_STRINGIZE(__LINE__) "): note: " x))
 #else
 #define BOOST_PRAGMA_MESSAGE(x)
 #endif

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -103,6 +103,7 @@ test-suite config
     [ run cstdint_test2.cpp : : : <warnings>all <toolset>gcc:<cxxflags>"-Wno-long-long -Wextra" <toolset>darwin:<cxxflags>-Wno-long-long ]
     [ compile cstdint_include_test.cpp : <warnings>all <toolset>gcc:<cxxflags>-Wextra ]
     [ run config_build_check.cpp : : : [ requires int128 cxx11_constexpr cxx11_user_defined_literals ] ]
+    [ run helper_macros_test.cpp ]
     [ compile pragma_message_test.cpp ]
   ;
 

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -103,6 +103,7 @@ test-suite config
     [ run cstdint_test2.cpp : : : <warnings>all <toolset>gcc:<cxxflags>"-Wno-long-long -Wextra" <toolset>darwin:<cxxflags>-Wno-long-long ]
     [ compile cstdint_include_test.cpp : <warnings>all <toolset>gcc:<cxxflags>-Wextra ]
     [ run config_build_check.cpp : : : [ requires int128 cxx11_constexpr cxx11_user_defined_literals ] ]
+    [ compile pragma_message_test.cpp ]
   ;
 
 obj has_clang_implicit_fallthrough : cmd_line_check.cpp :

--- a/test/helper_macros_test.cpp
+++ b/test/helper_macros_test.cpp
@@ -1,0 +1,30 @@
+//  Copyright 2017 Peter Dimov.
+//
+//  Distributed under the Boost Software License, Version 1.0.
+//
+//  See accompanying file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt
+
+#include <boost/config/helper_macros.hpp>
+#include <boost/core/lightweight_test.hpp>
+
+int main()
+{
+#define X pumpkin
+
+    BOOST_TEST_CSTR_EQ( BOOST_STRINGIZE(X), "pumpkin" );
+    BOOST_TEST_CSTR_EQ( BOOST_STRINGIZE(__LINE__), "16" );
+
+#define Y 2
+
+    int BOOST_JOIN(X, Y) = 0;
+    (void)pumpkin2;
+
+    int BOOST_JOIN(X, __LINE__) = 0;
+    (void)pumpkin23;
+
+    BOOST_TEST_CSTR_EQ( BOOST_STRINGIZE(BOOST_JOIN(X, Y)), "pumpkin2" );
+    BOOST_TEST_CSTR_EQ( BOOST_STRINGIZE(BOOST_JOIN(X, __LINE__)), "pumpkin27" );
+
+    return boost::report_errors();
+}

--- a/test/pragma_message_test.cpp
+++ b/test/pragma_message_test.cpp
@@ -1,0 +1,18 @@
+//  Copyright 2017 Peter Dimov.
+//
+//  Distributed under the Boost Software License, Version 1.0.
+//
+//  See accompanying file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt
+
+#include <boost/config/pragma_message.hpp>
+
+BOOST_PRAGMA_MESSAGE("first message")
+
+#define MSG2 "second message"
+BOOST_PRAGMA_MESSAGE(MSG2)
+
+#include <boost/config.hpp> // BOOST_STRINGIZE
+
+#define MSG3 third message
+BOOST_PRAGMA_MESSAGE(BOOST_STRINGIZE(MSG3))


### PR DESCRIPTION
This PR adds `BOOST_PRAGMA_MESSAGE(M)`, a macro that expands to an equivalent on `#pragma message(M)`, when it's supported. In addition, on MSVC it adds `__FILE__` and `__LINE__` to the message, as the plain `#pragma message` has the problem that it's impossible to tell where the message originated.

Since there are places where Boost.Config itself emits messages using the preprocessor, the best place for this utility macro is in Config so that it can be used inside.

This PR includes #194. Also includes a few unrelated doc fixes and regenerates the HTML.