### PR TITLE
Variable templates are somewhat unusable in GCC 5.1 (bug 65719)

### DIFF
--- a/include/boost/config/compiler/gcc.hpp
+++ b/include/boost/config/compiler/gcc.hpp
@@ -285,7 +285,7 @@
 #if !defined(__cpp_constexpr) || (__cpp_constexpr < 201304)
 #  define BOOST_NO_CXX14_CONSTEXPR
 #endif
-#if !defined(__cpp_variable_templates) || (__cpp_variable_templates < 201304)
+#if (BOOST_GCC_VERSION < 50200) || !defined(__cpp_variable_templates) || (__cpp_variable_templates < 201304)
 #  define BOOST_NO_CXX14_VARIABLE_TEMPLATES
 #endif
 


### PR DESCRIPTION
The are only two uses of BOOST_NO_CXX14_VARIABLE_TEMPLATES in Boost right now: Boost.Align (for alignment_of only) and Boost.TypeTraits (for the detection idiom toolkit only), so this should have minimal impact.