### PR TITLE
Use dllimport/dllexport with clang and gcc on Cygwin.

### DIFF
--- a/include/boost/config/compiler/clang.hpp
+++ b/include/boost/config/compiler/clang.hpp
@@ -98,11 +98,15 @@
 //
 // Dynamic shared object (DSO) and dynamic-link library (DLL) support
 //
-#if !defined(_WIN32) && !defined(__WIN32__) && !defined(WIN32)
+#if defined(_WIN32) || defined(__WIN32__) || defined(WIN32) || defined(__CYGWIN__)
+#  define BOOST_HAS_DECLSPEC
+#  define BOOST_SYMBOL_EXPORT __attribute__((__dllexport__))
+#  define BOOST_SYMBOL_IMPORT __attribute__((__dllimport__))
+#else
 #  define BOOST_SYMBOL_EXPORT __attribute__((__visibility__("default")))
 #  define BOOST_SYMBOL_IMPORT
-#  define BOOST_SYMBOL_VISIBLE __attribute__((__visibility__("default")))
 #endif
+#define BOOST_SYMBOL_VISIBLE __attribute__((__visibility__("default")))
 
 //
 // The BOOST_FALLTHROUGH macro can be used to annotate implicit fall-through

--- a/include/boost/config/compiler/gcc.hpp
+++ b/include/boost/config/compiler/gcc.hpp
@@ -99,10 +99,10 @@
 // Dynamic shared object (DSO) and dynamic-link library (DLL) support
 //
 #if __GNUC__ >= 4
-#  if (defined(_WIN32) || defined(__WIN32__) || defined(WIN32)) && !defined(__CYGWIN__)
+#  if defined(_WIN32) || defined(__WIN32__) || defined(WIN32) || defined(__CYGWIN__)
      // All Win32 development environments, including 64-bit Windows and MinGW, define
      // _WIN32 or one of its variant spellings. Note that Cygwin is a POSIX environment,
-     // so does not define _WIN32 or its variants.
+     // so does not define _WIN32 or its variants, but still supports dllexport/dllimport.
 #    define BOOST_HAS_DECLSPEC
 #    define BOOST_SYMBOL_EXPORT __attribute__((__dllexport__))
 #    define BOOST_SYMBOL_IMPORT __attribute__((__dllimport__))


### PR DESCRIPTION
This is required at least for Boost.WinAPI to match the declarations in
Windows SDK headers, which use dllimport.

Also, for clang on Windows, use dllimport/dllexport even beyond Cygwin.
The compiler does support these attributes, and it should for
compatibility with Windows headers.