### PR TITLE
Undefine BOOST_GCC for intel compilers

### DIFF
--- a/include/boost/config/compiler/intel.hpp
+++ b/include/boost/config/compiler/intel.hpp
@@ -45,6 +45,7 @@
 
 #undef BOOST_GCC_VERSION
 #undef BOOST_GCC_CXX11
+#undef BOOST_GCC
 
 // Broken in all versions up to 17 (newer versions not tested)
 #if (__INTEL_COMPILER <= 1700) && !defined(BOOST_NO_CXX14_CONSTEXPR)


### PR DESCRIPTION
Also, this doesn't fix it, but apparently intel compilers don't support `__attribute__((fallthrough))` but BOOST_FALLTHROUGH is defined by the gcc config, according to the beast test results:

http://www.boost.org/development/tests/master/developer/output/intel-linux-master-boost-bin-v2-libs-beast-test-beast-websocket-accept-test-intel-linux-linux-debug-threadapi-pthread-threading-multi.html