### PR TITLE
cmake: Install headers and exported configuration

### DIFF
--- a/BoostConfigConfig.cmake.in
+++ b/BoostConfigConfig.cmake.in
@@ -1,0 +1,3 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/BoostConfigInternal.cmake")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,12 +16,6 @@
 cmake_minimum_required(VERSION 3.5)
 project(BoostConfig VERSION 1.69 LANGUAGES CXX)
 
-# Globbing is not recommended, but it matches the b2 behaviour for
-# now.  Should be a static list.
-file(GLOB_RECURSE boost_config_headers
-  RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}/include"
-  CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/include/boost/*")
-
 add_library(boost_config INTERFACE)
 add_library(Boost::config ALIAS boost_config)
 
@@ -33,13 +27,9 @@ set_target_properties(boost_config PROPERTIES EXPORT_NAME "Boost::config")
 
 # Install headers
 include(GNUInstallDirs)
-foreach(header ${boost_config_headers})
-  get_filename_component(header_name "${header}" NAME)
-  get_filename_component(header_dir "${header}" DIRECTORY)
-  install(FILES "include/${header}"
-    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${header_dir}"
-    COMPONENT "development")
-endforeach()
+install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/boost"
+  DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+  COMPONENT "development")
 
 # Install exported configuration
 if(WIN32)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright 2018 Mike Dev
+# Copyright 2018 Roger Leigh
 # Distributed under the Boost Software License, Version 1.0.
 # See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt
 #
@@ -13,9 +14,62 @@
 #
 
 cmake_minimum_required(VERSION 3.5)
-project(BoostConfig LANGUAGES CXX)
+project(BoostConfig VERSION 1.69 LANGUAGES CXX)
+
+# Globbing is not recommended, but it matches the b2 behaviour for
+# now.  Should be a static list.
+file(GLOB_RECURSE boost_config_headers
+  RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}/include"
+  CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/include/boost/*")
 
 add_library(boost_config INTERFACE)
 add_library(Boost::config ALIAS boost_config)
 
-target_include_directories(boost_config INTERFACE include)
+target_include_directories(boost_config INTERFACE
+  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+
+set_target_properties(boost_config PROPERTIES EXPORT_NAME "Boost::config")
+
+# Install headers
+include(GNUInstallDirs)
+foreach(header ${boost_config_headers})
+  get_filename_component(header_name "${header}" NAME)
+  get_filename_component(header_dir "${header}" DIRECTORY)
+  install(FILES "include/${header}"
+    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${header_dir}"
+    COMPONENT "development")
+endforeach()
+
+# Install exported configuration
+if(WIN32)
+  set(boost_config_config_dir "cmake")
+else()
+  set(boost_config_config_dir "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
+endif()
+
+install(TARGETS boost_config
+        EXPORT BoostConfigInternal
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        COMPONENT "runtime"
+        INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+install(EXPORT BoostConfigInternal
+        DESTINATION "${boost_config_config_dir}"
+        COMPONENT "development")
+include(CMakePackageConfigHelpers)
+configure_package_config_file(
+  "${CMAKE_CURRENT_SOURCE_DIR}/${PROJECT_NAME}Config.cmake.in"
+  "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+  INSTALL_DESTINATION "${boost_config_config_dir}")
+write_basic_package_version_file(
+  ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
+  VERSION "${PROJECT_VERSION}"
+  COMPATIBILITY SameMinorVersion)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
+              ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
+        DESTINATION "${boost_config_config_dir}"
+        COMPONENT "development")
+
+add_subdirectory(test)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,9 +40,6 @@ endif()
 
 install(TARGETS boost_config
         EXPORT BoostConfigInternal
-        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
         COMPONENT "runtime"
         INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
 install(EXPORT BoostConfigInternal

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,5 +61,3 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
               ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
         DESTINATION "${boost_config_config_dir}"
         COMPONENT "development")
-
-add_subdirectory(test)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -18,6 +18,8 @@
 #
 cmake_minimum_required(VERSION 3.5)
 
+add_subdirectory(.. ${CMAKE_CURRENT_BINARY_DIR}/boost_config)
+
 find_package(Threads)
 
 add_executable(config_info config_info.cpp)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright 2018 John Maddock
+# Copyright 2018 Roger Leigh
 # Distributed under the Boost Software License, Version 1.0.
 # See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt
 #
@@ -16,12 +17,12 @@
 # want to import these projects into their IDE.
 #
 cmake_minimum_required(VERSION 3.5)
-  
-add_subdirectory(.. ${CMAKE_CURRENT_BINARY_DIR}/boost_config)
-  
-add_executable(config_info config_info.cpp)  
-target_link_libraries(config_info Boost::config)  
 
-add_executable(config_test config_test.cpp)  
-target_link_libraries(config_test Boost::config)  
+find_package(Threads)
+
+add_executable(config_info config_info.cpp)
+target_link_libraries(config_info Boost::config Threads::Threads)
+
+add_executable(config_test config_test.cpp)
+target_link_libraries(config_test Boost::config Threads::Threads)
 


### PR DESCRIPTION
Initial work for https://github.com/boostorg/config/issues/247 which extends the existing two cmake files.  This makes it possible to install the headers with `make install` and it also builds two tests.  It additionally installs a configuration file so that you can run e.g.

```
find_package(BoostConfig VERSION 1.69 REQUIRED)
```

and then be able to use

```
target_link_libraries(foo Boost::config)
```

in any downstream project making use of Boost.Config.  The generated configuration is put into a "BoostConfigInternal" script, which is then sourced by a minimal "BoostConfig" script.  This is so that we can set additional variables for build-time configuration in this top-level script as follow-on work.

Quite a few bits of the logic here could be generalised and reused by other Boost components as done by BCM.  However, for now I have kept it dead simple.  It's easy enough to refactor it later on to be more complex.  This is the minimal work needed to make it possible to use Boost::config in other projects.


Hope this is useful,
Roger