### PR TITLE
Fix BOOST_NO_FENV_H on cygwin (it exists since 2010...)

### DIFF
--- a/include/boost/config/platform/cygwin.hpp
+++ b/include/boost/config/platform/cygwin.hpp
@@ -42,8 +42,11 @@
 #   define BOOST_HAS_STDINT_H
 #endif
 
+#include <cygwin/version.h>
+#if (CYGWIN_VERSION_API_MAJOR == 0 && CYGWIN_VERSION_API_MINOR < 231)
 /// Cygwin has no fenv.h
 #define BOOST_NO_FENV_H
+#endif
 
 // Cygwin has it's own <pthread.h> which breaks <shared_mutex> unless the correct compiler flags are used:
 #ifndef BOOST_NO_CXX14_HDR_SHARED_MUTEX


### PR DESCRIPTION
I tested this in a private build on AppVeyor CI against numeric/interval where the problem originally surfaced.  This build job failed without the change:

https://ci.appveyor.com/project/jeking3/interval/builds/19983035/job/9glx1bs1r28a421l

Ref:

https://github.com/Alexpux/Cygwin/commit/0f81b5d4bcaa5c840031796d94df9ba6d6fae4d0#diff-447ff859802166057451911061326417R390

Thanks.