### PR TITLE
Fix Cygwin build.

### DIFF
--- a/include/boost/config/stdlib/libstdcpp3.hpp
+++ b/include/boost/config/stdlib/libstdcpp3.hpp
@@ -36,6 +36,7 @@
         || defined(_GLIBCXX__PTHREADS) \
         || defined(_GLIBCXX_HAS_GTHREADS) \
         || defined(_WIN32) \
+        || defined(__CYGWIN__) \
         || defined(_AIX) \
         || defined(__HAIKU__)
       //


### PR DESCRIPTION
Without this I see the following error (cygwin, gcc-8.2.0, boost 1.69.0):
```
In file included from d:/dev/cppan2_storage/pkg/fb/cc/14/03/9dd1/src/sdir/include/boost/thread/detail/platform.hpp:17,
                 from d:/dev/cppan2_storage/pkg/fb/cc/14/03/9dd1/src/sdir/include/boost/thread/detail/config.hpp:13,
                 from d:/dev/cppan2_storage/pkg/fb/cc/14/03/9dd1/src/sdir/src/pthread/once.cpp:6:
d:/dev/cppan2_storage/pkg/a3/34/a0/78/8681/src/sdir/include/boost/config/requires_threads.hpp:29:4: error: #error "Threading support unavaliable: it has been explicitly disabled with BOOST_DISABLE_THREADS"
 #  error "Threading support unavaliable: it has been explicitly disabled with BOOST_DISABLE_THREADS"
    ^~~~~
```

ps:
It is possible that for some reason I've got bad gcc/libstdc++ build, so explicit statement is needed.

pps: 
Yes, seems bad gcc config. Sorry.