### PR TITLE
__builtin_unreachable was introduced in GCC 4.5

### DIFF
--- a/include/boost/config/compiler/gcc.hpp
+++ b/include/boost/config/compiler/gcc.hpp
@@ -327,7 +327,7 @@
 
 //
 // __builtin_unreachable:
-#if BOOST_GCC_VERSION >= 40800
+#if BOOST_GCC_VERSION >= 40500
 #define BOOST_UNREACHABLE_RETURN(x) __builtin_unreachable();
 #endif
 


### PR DESCRIPTION
https://godbolt.org/z/7oXS2i