### PR TITLE
Lift thread local ban for 64bit MinGW

### DIFF
--- a/include/boost/config/compiler/gcc.hpp
+++ b/include/boost/config/compiler/gcc.hpp
@@ -309,8 +309,8 @@
 #  define BOOST_FALLTHROUGH __attribute__((fallthrough))
 #endif
 
-#ifdef __MINGW32__
-// Currently (June 2017) thread_local is broken on mingw for all current compiler releases, see
+#if defined(__MINGW32__) && !defined(__MINGW64__)
+// Currently (March 2019) thread_local is broken on mingw for all current 32bit compiler releases, see
 // https://sourceforge.net/p/mingw-w64/bugs/527/
 // Not setting this causes program termination on thread exit.
 #define BOOST_NO_CXX11_THREAD_LOCAL


### PR DESCRIPTION
The problem seems affect only 32bit compilers. See https://sourceforge.net/p/mingw-w64/bugs/527/#cedc.

ref https://github.com/boostorg/config/commit/fe5e07b521e49f6cca712c801e025fed13c23979#commitcomment-32969838