### PR TITLE
Enable auto link support for clang on windows (clang-win) (clang-cl)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,6 +22,10 @@ environment:
       ARGS: --toolset=msvc-14.1 address-model=32
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       ARGS: --toolset=msvc-14.1 address-model=64 cxxflags=-std:c++latest cxxflags=-permissive-
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      ARGS: --toolset=clang-win address-model=64
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      ARGS: --toolset=clang-win address-model=32
     - ARGS: --toolset=msvc-9.0  address-model=32
     - ARGS: --toolset=msvc-10.0 address-model=32
     - ARGS: --toolset=msvc-11.0 address-model=32

--- a/include/boost/config/auto_link.hpp
+++ b/include/boost/config/auto_link.hpp
@@ -99,7 +99,8 @@ BOOST_LIB_VERSION:    The Boost version, in the form x_y, for Boost version x.y.
 #if defined(BOOST_MSVC) \
     || defined(__BORLANDC__) \
     || (defined(__MWERKS__) && defined(_WIN32) && (__MWERKS__ >= 0x3000)) \
-    || (defined(__ICL) && defined(_MSC_EXTENSIONS) && (_MSC_VER >= 1200))
+    || (defined(__ICL) && defined(_MSC_EXTENSIONS) && (_MSC_VER >= 1200)) \
+    || (defined(BOOST_CLANG) && defined(BOOST_WINDOWS) && defined(_MSC_VER) && (__clang_major__ >= 4))
 
 #ifndef BOOST_VERSION_HPP
 #  include <boost/version.hpp>
@@ -202,6 +203,11 @@ BOOST_LIB_VERSION:    The Boost version, in the form x_y, for Boost version x.y.
 
      // Metrowerks CodeWarrior 9.x
 #    define BOOST_LIB_TOOLSET "cw9"
+
+#  elif defined(BOOST_CLANG) && defined(BOOST_WINDOWS) && defined(_MSC_VER) && (__clang_major__ >= 4)
+
+     // Clang on Windows
+#    define BOOST_LIB_TOOLSET "clangw" BOOST_STRINGIZE(__clang_major__)
 
 #  endif
 #endif // BOOST_LIB_TOOLSET


### PR DESCRIPTION
Also added two build jobs for toolset clang-win on Appveyor.

This fixes https://github.com/boostorg/uuid/issues/78
