### PR TITLE
Add BOOST_INLINE_VARIABLE macro

### DIFF
--- a/doc/macro_reference.qbk
+++ b/doc/macro_reference.qbk
@@ -936,7 +936,7 @@ provide compliant C++14 support.
 
 [table
 [[Macro ][ Description ]]
-[[`BOOST_CXX14_CONSTEXPR`][This macro works similar to BOOST_CONSTEXPR, but expands to `constexpr` only if the C++14 "relaxed" `constexpr` is available.]]
+[[`BOOST_CXX14_CONSTEXPR`][This macro works similar to `BOOST_CONSTEXPR`, but expands to `constexpr` only if the C++14 "relaxed" `constexpr` is available.]]
 ]
 
 [endsect]
@@ -955,6 +955,21 @@ that are not yet supported by a particular compiler or library.
 [[`BOOST_NO_CXX17_STD_INVOKE`][The compiler does not support `std::invoke()`.]]
 [[`BOOST_NO_CXX17_ITERATOR_TRAITS`][The compiler does not support SFINAE-friendly `std::iterator_traits`.]]
 [[`BOOST_NO_CXX17_IF_CONSTEXPR`][The compiler does not support `if constexpr`.]]
+[[`BOOST_NO_CXX17_INLINE_VARIABLES`][The compiler does not support `inline` variables.]]
+]
+
+[endsect]
+
+[#config_17_for_14]
+
+[section Macros that allow use of C++17 features with C++14 or earlier compilers]
+
+The following macros allow use of C++17 features even with compilers that do not yet
+provide compliant C++17 support.
+
+[table
+[[Macro ][ Description ]]
+[[`BOOST_INLINE_VARIABLE`][This macro expands to `inline` on compilers that support C++17 inline variables and to nothing otherwise. Users may need to check for `BOOST_NO_CXX17_INLINE_VARIABLES` for further adjustments to the code.]]
 ]
 
 [endsect]

--- a/include/boost/config/detail/suffix.hpp
+++ b/include/boost/config/detail/suffix.hpp
@@ -987,6 +987,15 @@ namespace std{ using ::type_info; }
 #endif
 
 //
+// C++17 inline variables
+//
+#if !defined(BOOST_NO_CXX17_INLINE_VARIABLES)
+#define BOOST_INLINE_VARIABLE inline
+#else
+#define BOOST_INLINE_VARIABLE
+#endif
+
+//
 // Unused variable/typedef workarounds:
 //
 #ifndef BOOST_ATTRIBUTE_UNUSED


### PR DESCRIPTION
The `BOOST_INLINE_VARIABLE` macro can be used to mark C++17 inline variables in contexts where omitting the `inline` keyword is still acceptable on older compilers.

A few use cases:

https://github.com/boostorg/atomic/blob/fc410975146a23e0513e8164009cc1eac2d9830b/include/boost/memory_order.hpp#L57
https://github.com/boostorg/core/issues/63
https://github.com/boostorg/optional/issues/33

This commit also adds the missing docs for `BOOST_NO_CXX17_INLINE_VARIABLES`.