### PR TITLE
Do not inject `typeinfo` into `std` namespace

### DIFF
--- a/include/boost/config/detail/suffix.hpp
+++ b/include/boost/config/detail/suffix.hpp
@@ -528,12 +528,6 @@ namespace boost {
 #  define BOOST_APPEND_EXPLICIT_TEMPLATE_NON_TYPE(t, v)
 #  define BOOST_APPEND_EXPLICIT_TEMPLATE_NON_TYPE_SPEC(t, v)
 
-// When BOOST_NO_STD_TYPEINFO is defined, we can just import
-// the global definition into std namespace:
-#if defined(BOOST_NO_STD_TYPEINFO) && defined(__cplusplus)
-#include <typeinfo>
-namespace std{ using ::type_info; }
-#endif
 
 // ---------------------------------------------------------------------------//
 

--- a/include/boost/config/stdlib/dinkumware.hpp
+++ b/include/boost/config/stdlib/dinkumware.hpp
@@ -86,16 +86,6 @@
 #  define BOOST_NO_STD_LOCALE
 #endif
 
-// Fix for VC++ 8.0 on up ( I do not have a previous version to test )
-// or clang-cl. If exceptions are off you must manually include the 
-// <exception> header before including the <typeinfo> header. Admittedly 
-// trying to use Boost libraries or the standard C++ libraries without 
-// exception support is not suggested but currently clang-cl ( v 3.4 ) 
-// does not support exceptions and must be compiled with exceptions off.
-#if !_HAS_EXCEPTIONS && ((defined(BOOST_MSVC) && BOOST_MSVC >= 1400) || (defined(__clang__) && defined(_MSC_VER)))
-#include <exception>
-#endif
-#include <typeinfo>
 #if ( (!_HAS_EXCEPTIONS && !defined(__ghs__)) || (defined(__ghs__) && !_HAS_NAMESPACE) ) && !defined(__TI_COMPILER_VERSION__) && !defined(__VISUALDSPVERSION__) \
    && !defined(__VXWORKS__)
 #  define BOOST_NO_STD_TYPEINFO


### PR DESCRIPTION
`BOOST_NO_STD_TYPEINFO` should be used to detect if there is no `typeinfo` in `std` namespace, or Boost.Core/Boost.TypeInfo wrappers for a portable solution.

Closes #306.