### PR TITLE
make mips1.cpp recognize all mips

### DIFF
--- a/checks/architecture/mips1.cpp
+++ b/checks/architecture/mips1.cpp
@@ -6,6 +6,6 @@
 // accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
-#if !((defined(__mips) && __mips == 1) || defined(_MIPS_ISA_MIPS1) || defined(_R3000))
+#if !(defined(__mips) || defined(_MIPS_ISA_MIPS1) || defined(_R3000))
 #error "Not MIPS1"
 #endif


### PR DESCRIPTION
currently mips1.cpp can only recognize mips 32bit (MIPS1 by __mips=1,
and mips2 above by R3000).

64bit cannot be recognized.
So drop the __mips==1 here.