### PR TITLE
Update CMakeLists.txt with install support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,8 @@ include(BoostInstall OPTIONAL RESULT_VARIABLE HAVE_BOOST_INSTALL)
 
 if(HAVE_BOOST_INSTALL)
 
+    install(DIRECTORY include/ DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+
     boost_install(boost_config)
 
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,13 +9,27 @@
 #
 # IT IS HIGHLY LIKELY THAT THIS FILE WILL CHANGE WITHOUT NOTICE!!!
 #
-# DO NOT REPLY ON THE CONTENTS OF THIS FILE!!!
+# DO NOT RELY ON THE CONTENTS OF THIS FILE!!!
 #
 
-cmake_minimum_required(VERSION 3.5)
-project(BoostConfig LANGUAGES CXX)
+cmake_minimum_required(VERSION 3.5...3.16)
+project(boost_config VERSION "${BOOST_SUPERPROJECT_VERSION}" LANGUAGES CXX)
 
 add_library(boost_config INTERFACE)
 add_library(Boost::config ALIAS boost_config)
 
-target_include_directories(boost_config INTERFACE include)
+set_property(TARGET boost_config PROPERTY EXPORT_NAME config)
+
+target_include_directories(boost_config
+    INTERFACE
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+        $<INSTALL_INTERFACE:include>
+)
+
+include(BoostInstall OPTIONAL RESULT_VARIABLE HAVE_BOOST_INSTALL)
+
+if(HAVE_BOOST_INSTALL)
+
+    boost_install(boost_config)
+
+endif()


### PR DESCRIPTION
This is necessary, because for a library to have install support, all the dependencies need to have it, and Config is a dependency of pretty much everything.