### PR TITLE
Increase gcc version for BOOST_NO_CXX11_ALIGNAS to 4.9

### DIFF
--- a/include/boost/config/compiler/gcc.hpp
+++ b/include/boost/config/compiler/gcc.hpp
@@ -254,7 +254,6 @@
 // C++0x features in 4.8.n and later
 //
 #if (BOOST_GCC_VERSION < 40800) || !defined(BOOST_GCC_CXX11)
-#  define BOOST_NO_CXX11_ALIGNAS
 #  define BOOST_NO_CXX11_THREAD_LOCAL
 #  define BOOST_NO_CXX11_SFINAE_EXPR
 #endif
@@ -265,6 +264,14 @@
 #  define BOOST_NO_CXX11_DECLTYPE_N3276
 #  define BOOST_NO_CXX11_REF_QUALIFIERS
 #  define BOOST_NO_CXX14_BINARY_LITERALS
+#endif
+
+// C++0x features in 4.9.n and later
+//
+#if (BOOST_GCC_VERSION < 40900) || !defined(BOOST_GCC_CXX11)
+// Although alignas support is added in gcc 4.8, it does not accept
+// constant expressions as an argument until gcc 4.9.
+#  define BOOST_NO_CXX11_ALIGNAS
 #endif
 
 // C++0x features in 5.1 and later

--- a/test/boost_no_cxx11_alignas.ipp
+++ b/test/boost_no_cxx11_alignas.ipp
@@ -1,4 +1,4 @@
-//  (C) Copyright Andrey Semashev 2013
+//  (C) Copyright Andrey Semashev 2013, 2020
 
 //  Use, modification and distribution are subject to the
 //  Boost Software License, Version 1.0. (See accompanying file
@@ -12,6 +12,12 @@
 
 namespace boost_no_cxx11_alignas {
 
+template< unsigned int Alignment >
+struct alignment
+{
+    static const unsigned int value = Alignment;
+};
+
 struct alignas(16) my_data1
 {
     char data[10];
@@ -22,10 +28,17 @@ struct alignas(double) my_data2
     char data[16];
 };
 
+struct alignas(alignment< 16u >::value) my_data3
+{
+    char data[16];
+};
+
 my_data1 dummy1[2];
 my_data2 dummy2;
-alignas(16) char dummy3[10];
-alignas(double) char dummy4[32];
+my_data3 dummy3;
+alignas(16) char dummy4[10];
+alignas(double) char dummy5[32];
+alignas(alignment< 16u >::value) char dummy6[32];
 
 int test()
 {


### PR DESCRIPTION
gcc 4.8 [appears](https://travis-ci.org/boostorg/atomic/jobs/656805795#L870) to not support `alignas` specifier with a constant expression as an argument. This PR updates the test to detect this and increases gcc version to 4.9.
