### PR TITLE
Further changes for Embarcadero C++ clang-based compilers

### DIFF
--- a/include/boost/config/compiler/codegear.hpp
+++ b/include/boost/config/compiler/codegear.hpp
@@ -111,30 +111,6 @@
 #  endif
 #endif /* defined(BOOST_EMBTC) */
 
-#if defined(BOOST_EMBTC_WINDOWS)
-
-/* The Windows SDK for Embarcadero has the deprecated 'chdir' function for _chdir
-   so make sure any call to _chdir becomes a call to chdir */
-   
-#  define _chdir chdir
-
-/* Undefine the symbols and the Windows platform will automatically define them for us
-   as appropriate */
-   
-#if defined(BOOST_SYMBOL_EXPORT)
-#undef BOOST_SYMBOL_EXPORT
-#endif
-
-#if defined(BOOST_SYMBOL_IMPORT)
-#undef BOOST_SYMBOL_IMPORT
-#endif
-
-#if defined(BOOST_SYMBOL_VISIBLE)
-#undef BOOST_SYMBOL_VISIBLE
-#endif
-
-#endif
-
 #  undef BOOST_COMPILER
 #  define BOOST_COMPILER "Embarcadero-Clang C++ version " BOOST_STRINGIZE(__CODEGEARC__) " clang: " __clang_version__
 // #  define __CODEGEARC_CLANG__ __CODEGEARC__

--- a/include/boost/config/compiler/codegear.hpp
+++ b/include/boost/config/compiler/codegear.hpp
@@ -111,6 +111,18 @@
 #  endif
 #endif /* defined(BOOST_EMBTC) */
 
+#if defined(BOOST_EMBTC_WINDOWS)
+
+#if !defined(_chdir)
+#define _chdir(x) chdir(x)
+#endif
+
+#if !defined(_dup2)
+#define _dup2(x,y) dup2(x,y)
+#endif
+
+#endif
+
 #  undef BOOST_COMPILER
 #  define BOOST_COMPILER "Embarcadero-Clang C++ version " BOOST_STRINGIZE(__CODEGEARC__) " clang: " __clang_version__
 // #  define __CODEGEARC_CLANG__ __CODEGEARC__

--- a/include/boost/config/compiler/codegear.hpp
+++ b/include/boost/config/compiler/codegear.hpp
@@ -15,12 +15,21 @@
 #  define BOOST_NO_CXX11_THREAD_LOCAL
 #  define BOOST_NO_CXX11_ATOMIC_SMART_PTR
 
+// 32 functions are missing from the current RTL in cwchar, so it really can not be used even if it exists
+
+#  define BOOST_NO_CWCHAR
+
 #  ifndef __MT__  /* If compiling in single-threaded mode, assume there is no CXX11_HDR_ATOMIC */
 #    define BOOST_NO_CXX11_HDR_ATOMIC
 #  endif
 
-#define BOOST_NO_FENV_H  /* temporarily disable this until we can link against fegetround fesetround feholdexcept */
-#define BOOST_NO_CXX11_HDR_EXCEPTION /* Reported this bug to Embarcadero with the latest C++ Builder Rio release */
+/* temporarily disable this until we can link against fegetround fesetround feholdexcept */
+
+#define BOOST_NO_FENV_H
+
+/* Reported this bug to Embarcadero with the latest C++ Builder Rio release */
+
+#define BOOST_NO_CXX11_HDR_EXCEPTION
 
 //
 // check for exception handling support:
@@ -103,33 +112,28 @@
 #endif /* defined(BOOST_EMBTC) */
 
 #if defined(BOOST_EMBTC_WINDOWS)
-   // About TR1 headers and features:
-   // BOOST_HAS_TR1_*-style definitions are placed in "boost\tr1\detail\config.hpp",
-   // because there, they will always be found, but here, they may be not check.
 
-   //   // This is needed to allow 64-bit integers in cstdint.hpp
-   //#  define BOOST_HAS_MS_INT64
+/* The Windows SDK for Embarcadero has the deprecated 'chdir' function for _chdir
+   so make sure any call to _chdir becomes a call to chdir */
+   
+#  define _chdir chdir
 
-   //#  define BOOST_HAS_RVALUE_REFS
+/* Undefine the symbols and the Windows platform will automatically define them for us
+   as appropriate */
+   
+#if defined(BOOST_SYMBOL_EXPORT)
+#undef BOOST_SYMBOL_EXPORT
+#endif
 
-   //   // Boost.Fusion should not use its preprocessed templates,
-   //   // due to we can use its variadic cpp11 templates. If that
-   //   // macro is not defined it tries to use both at the same time
-   //   // giving a redefinition error.
-   //#  define BOOST_FUSION_DONT_USE_PREPROCESSED_FILES
+#if defined(BOOST_SYMBOL_IMPORT)
+#undef BOOST_SYMBOL_IMPORT
+#endif
 
-   //   // Bcc64 don't have this <fenv.h> header
-   //#  define BOOST_NO_FENV_H
+#if defined(BOOST_SYMBOL_VISIBLE)
+#undef BOOST_SYMBOL_VISIBLE
+#endif
 
-   //   // This is not necessary with the last versions of bcc64
-   //#  if !defined(__FUNC__)
-   //#    define __FUNC__ __func__
-   //#  endif
-
-   // FVTODO: This was uncommended with 1_55 - prolly worth testing this by uncommenting it.
-   // Dinkumware on Win32 and Win64 platforms has <cstdint>
-   // #  define BOOST_HAS_STDINT_H
-#endif /* BOOST_EMBTC_WINDOWS */
+#endif
 
 #  undef BOOST_COMPILER
 #  define BOOST_COMPILER "Embarcadero-Clang C++ version " BOOST_STRINGIZE(__CODEGEARC__) " clang: " __clang_version__

--- a/include/boost/config/compiler/codegear.hpp
+++ b/include/boost/config/compiler/codegear.hpp
@@ -9,6 +9,17 @@
 
 //  CodeGear C++ compiler setup:
 
+//
+// versions check:
+// last known and checked version is 0x740
+#if (__CODEGEARC__ > 0x740)
+#  if defined(BOOST_ASSERT_CONFIG)
+#     error "boost: Unknown compiler version - please run the configure tests and report the results"
+#  else
+#     pragma message( "boost: Unknown compiler version - please run the configure tests and report the results")
+#  endif
+#endif
+
 #ifdef __clang__ // Clang enhanced Windows compiler
 
 #  include "clang.hpp"
@@ -141,16 +152,6 @@
 # pragma warn -8066 // dead code can never execute
 # pragma warn -8104 // static members with ctors not threadsafe
 # pragma warn -8105 // reference member in class without ctors
-#endif
-//
-// versions check:
-// last known and checked version is 0x621
-#if (__CODEGEARC__ > 0x740)
-#  if defined(BOOST_ASSERT_CONFIG)
-#     error "boost: Unknown compiler version - please run the configure tests and report the results"
-#  else
-#     pragma message( "boost: Unknown compiler version - please run the configure tests and report the results")
-#  endif
 #endif
 
 // CodeGear C++ Builder 2009

--- a/include/boost/config/detail/suffix.hpp
+++ b/include/boost/config/detail/suffix.hpp
@@ -35,7 +35,7 @@
 #endif
 
 //
-// ensure that visibility macros are always defined, thus symplifying use
+// ensure that visibility macros are always defined, thus simplifying use
 //
 #ifndef BOOST_SYMBOL_EXPORT
 # define BOOST_SYMBOL_EXPORT

--- a/include/boost/config/stdlib/dinkumware.hpp
+++ b/include/boost/config/stdlib/dinkumware.hpp
@@ -98,7 +98,7 @@
 #endif
 #include <typeinfo>
 #if ( (!_HAS_EXCEPTIONS && !defined(__ghs__)) || (defined(__ghs__) && !_HAS_NAMESPACE) ) && !defined(__TI_COMPILER_VERSION__) && !defined(__VISUALDSPVERSION__) \
-   && !defined(__VXWORKS__)
+   && !defined(__VXWORKS__) && !defined(BOOST_EMBTC_WINDOWS)
 #  define BOOST_NO_STD_TYPEINFO
 #endif  
 #endif

--- a/test/boost_no_cwchar.ipp
+++ b/test/boost_no_cwchar.ipp
@@ -18,6 +18,9 @@ int test()
 {
    wchar_t c1[2] = { 0 };
    wchar_t c2[2] = { 0 };
+   char    c3[2] = { 0 };
+   mbstate_t mb = mbstate_t();
+   if(!mbsinit(&mb) || mbrlen(c3,1,&mb)) return -1;
    if(wcscmp(c1,c2) || wcslen(c1)) return -1;
    //wcscpy(c1,c2);
    wcsxfrm(c1,c2,0);


### PR DESCRIPTION
I discovered through testing some issues and made further changes to the Embarcadero C++ clang-based compilers support in config. I also updated the test for support of the cwchars header file involving a basic test for multi-byte character support in the header file. The Embarcadero C++ clang-based compilers were passing the test but were actually missing all the multi-byte support in the header file, including all wide character to multi-byte and all the multi-byte to wide character functionality in the header file. So I felt updating the test slightly just to make sure that multi-byte support existed in its most basic form was necessary. I do not think this will affect any other compilers, and in my testing all the compilers I tested were not affected in any way by failing the test where previously they may have passed it.