### PR TITLE
Turn off 128-bit integer for Embarcadero C++ clang-based compilers. U…

### DIFF
--- a/include/boost/config/compiler/codegear.hpp
+++ b/include/boost/config/compiler/codegear.hpp
@@ -31,6 +31,9 @@
 #if defined(BOOST_HAS_INT128)
 #undef BOOST_HAS_INT128
 #endif
+#if defined(BOOST_HAS_FLOAT128)
+#undef BOOST_HAS_FLOAT128
+#endif
 
 // 32 functions are missing from the current RTL in cwchar, so it really can not be used even if it exists
 

--- a/include/boost/config/compiler/codegear.hpp
+++ b/include/boost/config/compiler/codegear.hpp
@@ -26,6 +26,12 @@
 #  define BOOST_NO_CXX11_THREAD_LOCAL
 #  define BOOST_NO_CXX11_ATOMIC_SMART_PTR
 
+// This bug has been reported to Embarcadero
+
+#if defined(BOOST_HAS_INT128)
+#undef BOOST_HAS_INT128
+#endif
+
 // 32 functions are missing from the current RTL in cwchar, so it really can not be used even if it exists
 
 #  define BOOST_NO_CWCHAR

--- a/test/boost_has_float128.ipp
+++ b/test/boost_has_float128.ipp
@@ -22,6 +22,10 @@ int test()
    __float128 big_float = 0.0Q;
 #endif
    (void)&big_float;
+   
+   __float128 i(2.00), j(1.00), k;
+   k = i / j;
+   
    return 0;
 }
 

--- a/test/boost_has_int128.ipp
+++ b/test/boost_has_int128.ipp
@@ -63,6 +63,9 @@ int test()
       fputs("Incorrect computation result.", stderr);
       return 1;
    }
+   
+   my_uint128_t i(2), j(1), k;
+   k = i / j;
 
    return 0;
 }

--- a/test/boost_has_int128.ipp
+++ b/test/boost_has_int128.ipp
@@ -64,8 +64,8 @@ int test()
       return 1;
    }
    
-   my_uint128_t i(2), j(1), k;
-   k = i / j;
+   my_uint128_t ii(2), jj(1), kk;
+   kk = ii / jj;
 
    return 0;
 }


### PR DESCRIPTION
…pdate the test for 128-bit integers.