### PR TITLE
Atomic exchange for 16 bytes does not work for Embarcadero C++ clang-…

### DIFF
--- a/include/boost/config/compiler/codegear.hpp
+++ b/include/boost/config/compiler/codegear.hpp
@@ -35,6 +35,10 @@
 #undef BOOST_HAS_FLOAT128
 #endif
 
+// The clang-based compilers can not do 128 atomic exchanges
+
+#define BOOST_ATOMIC_NO_CMPXCHG16B
+
 // 32 functions are missing from the current RTL in cwchar, so it really can not be used even if it exists
 
 #  define BOOST_NO_CWCHAR

--- a/include/boost/config/detail/suffix.hpp
+++ b/include/boost/config/detail/suffix.hpp
@@ -634,7 +634,7 @@ namespace std{ using ::type_info; }
 #if !defined(BOOST_NORETURN)
 #  if defined(_MSC_VER)
 #    define BOOST_NORETURN __declspec(noreturn)
-#  elif defined(__GNUC__)
+#  elif defined(__GNUC__) || defined(__CODEGEARC__) && defined(__clang__)
 #    define BOOST_NORETURN __attribute__ ((__noreturn__))
 #  elif defined(__has_attribute) && defined(__SUNPRO_CC) && (__SUNPRO_CC > 0x5130)
 #    if __has_attribute(noreturn)


### PR DESCRIPTION
…based compilers.