### PR TITLE
Changes for Embarcadero C++ clang-based compilers, targeting Boost 1.74. Documented the basic Embarcadero macros. I did not document the exten…

### DIFF
--- a/doc/macro_reference.qbk
+++ b/doc/macro_reference.qbk
@@ -1389,6 +1389,18 @@ compiler version macro.
 [[`BOOST_CLANG`][`<boost/config.hpp>`][
 Defined to 1 if the compiler is the Clang compiler.
 ]]
+[[`BOOST_BORLANDC`][`<boost/config.hpp>`][
+Defined to the value of __BORLANDC__ if the compiler is the Embarcadero
+non-clang based compiler.
+]]
+[[`BOOST_CODEGEARC`][`<boost/config.hpp>`][
+Defined to the value of __CODEGEARC__ if the compiler is the Embarcadero
+non-clang based compiler.
+]]
+[[`BOOST_EMBTC`][`<boost/config.hpp>`][
+Defined to the value of __CODEGEARC__ if the compiler is the Embarcadero
+clang based compiler.
+]]
 [[`BOOST_WINDOWS`][`<boost/config.hpp>`][
 Defined if the Windows platform API is available.
 ]]

--- a/include/boost/config/compiler/borland.hpp
+++ b/include/boost/config/compiler/borland.hpp
@@ -17,7 +17,7 @@
 #endif
 
 // last known compiler version:
-#if (__BORLANDC__ > 0x740)
+#if (__BORLANDC__ > 0x613)
 //#  if defined(BOOST_ASSERT_CONFIG)
 #     error "boost: Unknown compiler version - please run the configure tests and report the results"
 //#  else

--- a/include/boost/config/compiler/codegear.hpp
+++ b/include/boost/config/compiler/codegear.hpp
@@ -106,26 +106,26 @@
 // Detecting which Embarcadero driver is being used
 #if defined(BOOST_EMBTC)
 #  if defined(_WIN64)
-#    define BOOST_EMBTC_WIN64
-#    define BOOST_EMBTC_WINDOWS
+#    define BOOST_EMBTC_WIN64 1
+#    define BOOST_EMBTC_WINDOWS 1
 #    ifndef BOOST_USE_WINDOWS_H
 #      define BOOST_USE_WINDOWS_H
 #    endif
 #  elif defined(_WIN32)
-#    define BOOST_EMBTC_WIN32C
-#    define BOOST_EMBTC_WINDOWS
+#    define BOOST_EMBTC_WIN32C 1
+#    define BOOST_EMBTC_WINDOWS 1
 #    ifndef BOOST_USE_WINDOWS_H
 #      define BOOST_USE_WINDOWS_H
 #    endif
 #  elif defined(__APPLE__) && defined(__arm__)
-#    define BOOST_EMBTC_IOSARM
-#    define BOOST_EMBTC_IOS
+#    define BOOST_EMBTC_IOSARM 1
+#    define BOOST_EMBTC_IOS 1
 #  elif defined(__APPLE__) && defined(__aarch64__)
-#    define BOOST_EMBTC_IOSARM64
-#    define BOOST_EMBTC_IOS
+#    define BOOST_EMBTC_IOSARM64 1
+#    define BOOST_EMBTC_IOS 1
 #  elif defined(__ANDROID__) && defined(__arm__)
-#    define BOOST_EMBTC_AARM
-#    define BOOST_EMBTC_ANDROID
+#    define BOOST_EMBTC_AARM 1
+#    define BOOST_EMBTC_ANDROID 1
 #  elif
 #    if defined(BOOST_ASSERT_CONFIG)
 #       error "Unknown Embarcadero driver"


### PR DESCRIPTION
…ded Embarcadero macros beginning with BOOST_EMBTC_ but I did define them all to the value of 1 whereas before they were just defined to an empty value.