### PR TITLE
Remove prefix from feature check messages

### DIFF
--- a/checks/config.jam
+++ b/checks/config.jam
@@ -12,9 +12,7 @@ rule requires ( names + )
    local result ;
    for name in $(names)
    {
-      local msg = "Boost.Config Feature Check: " ;
-      msg += $(name) ;
-      result += [ check-target-builds $(config-binding:D)//$(name) $(msg:J=) : : <build>no ] ;
+      result += [ check-target-builds $(config-binding:D)//$(name) $(name) : : <build>no ] ;
    }
    return $(result) ;
 }


### PR DESCRIPTION
This PR removes the "Boost.Config Feature Check:" prefix from the feature check messages. It's repetitive, takes up horizontal space, and the messages are still clear enough without it.