### PR TITLE
Do not use C++98 binders when _GLIBCXX_USE_DEPRECATED=0

### DIFF
--- a/include/boost/config/stdlib/libstdcpp3.hpp
+++ b/include/boost/config/stdlib/libstdcpp3.hpp
@@ -216,6 +216,7 @@ extern "C" char *gets (char *__s);
 #     endif
 #  elif !_GLIBCXX_USE_DEPRECATED
 #     define BOOST_NO_AUTO_PTR
+#     define BOOST_NO_CXX98_BINDERS
 #  endif
 #endif
 


### PR DESCRIPTION
They are not available from libstdc++ in that case. This has been the case since 2007 ([see GCC commit, in libstdc++-v3/include/bits/stl_function.h](https://gcc.gnu.org/git/?p=gcc.git;a=commit;h=40abbf1f1737b16b1ae6a8d8094e825f6a3b41f2)). I've only added the define to the _GLIBCXX_USE_DEPRECATED branch, because that is the only define checked in the original GCC commit.

With this change Boost builds correctly with _GLIBCXX_USE_DEPRECATED=0.