### PR TITLE
Don't add address model in Embarcadero toolset name

### DIFF
--- a/include/boost/config/auto_link.hpp
+++ b/include/boost/config/auto_link.hpp
@@ -190,7 +190,7 @@ BOOST_LIB_SUFFIX:     Static/import libraries extension (".lib", ".a") for the c
 #  elif defined(BOOST_EMBTC_WINDOWS)
 
      // Embarcadero Clang based compilers:
-#    define BOOST_LIB_TOOLSET "bcb"
+#    define BOOST_LIB_TOOLSET "embtc"
 
 #  elif defined(BOOST_BORLANDC)
 

--- a/include/boost/config/auto_link.hpp
+++ b/include/boost/config/auto_link.hpp
@@ -190,11 +190,7 @@ BOOST_LIB_SUFFIX:     Static/import libraries extension (".lib", ".a") for the c
 #  elif defined(BOOST_EMBTC_WINDOWS)
 
      // Embarcadero Clang based compilers:
-#    if defined(BOOST_EMBTC_WIN32C)
-#      define BOOST_LIB_TOOLSET "bcb32"
-#    elif defined(BOOST_EMBTC_WIN64)
-#      define BOOST_LIB_TOOLSET "bcb64"
-#    endif
+#    define BOOST_LIB_TOOLSET "bcb"
 
 #  elif defined(BOOST_BORLANDC)
 


### PR DESCRIPTION
None of the other toolset names include a 32/64-bit indicator. Remove the `32`/`64` and change the name to `embtc` to match with boostorg/build#675, so that auto-linking actually works.