### PR TITLE
Update the test for C++11 alignas to trigger failure on gcc 4.8

### DIFF
--- a/include/boost/config/compiler/gcc.hpp
+++ b/include/boost/config/compiler/gcc.hpp
@@ -271,7 +271,7 @@
 //
 #if (BOOST_GCC_VERSION < 40900) || !defined(BOOST_GCC_CXX11)
 // Although alignas support is added in gcc 4.8, it does not accept
-// constant expressions as an argument until gcc 4.9.
+// dependent constant expressions as an argument until gcc 4.9.
 #  define BOOST_NO_CXX11_ALIGNAS
 #endif
 

--- a/test/boost_no_cxx11_alignas.ipp
+++ b/test/boost_no_cxx11_alignas.ipp
@@ -12,10 +12,10 @@
 
 namespace boost_no_cxx11_alignas {
 
-template< unsigned int Alignment >
-struct alignment
+template< typename T >
+struct alignment_of
 {
-    static const unsigned int value = Alignment;
+    static const unsigned int value = sizeof(T);
 };
 
 struct alignas(16) my_data1
@@ -28,17 +28,18 @@ struct alignas(double) my_data2
     char data[16];
 };
 
-struct alignas(alignment< 16u >::value) my_data3
+template< typename T >
+struct alignas(alignment_of< T >::value) my_data3
 {
     char data[16];
 };
 
 my_data1 dummy1[2];
 my_data2 dummy2;
-my_data3 dummy3;
+my_data3< int > dummy3;
 alignas(16) char dummy4[10];
 alignas(double) char dummy5[32];
-alignas(alignment< 16u >::value) char dummy6[32];
+alignas(alignment_of< int >::value) char dummy6[32];
 
 int test()
 {


### PR DESCRIPTION
Closes https://github.com/boostorg/config/issues/358.