### PR TITLE
Fix BOOST_NO_CXX20_HDR_RANGES

### DIFF
--- a/include/boost/config/detail/suffix.hpp
+++ b/include/boost/config/detail/suffix.hpp
@@ -1170,7 +1170,7 @@ namespace std{ using ::type_info; }
 #if !__has_include(<concepts>)
 #  define BOOST_NO_CXX20_HDR_CONCEPTS
 #endif
-#if !__has_include(<range>)
+#if !__has_include(<ranges>)
 #  define BOOST_NO_CXX20_HDR_RANGES
 #endif
 #if !__has_include(<syncstream>)


### PR DESCRIPTION
Corrects minor typo in the name of the header.