### PR TITLE
Allow thread_local on mingw with gcc>=11

### DIFF
--- a/include/boost/config/compiler/gcc.hpp
+++ b/include/boost/config/compiler/gcc.hpp
@@ -323,9 +323,10 @@
 #  define BOOST_FALLTHROUGH __attribute__((fallthrough))
 #endif
 
-#if defined(__MINGW32__) && !defined(__MINGW64__)
-// Currently (March 2019) thread_local is broken on mingw for all current 32bit compiler releases, see
+#if (__GNUC__ < 11) && defined(__MINGW32__) && !defined(__MINGW64__)
+// thread_local was broken on mingw for all 32bit compiler releases prior to 11.x, see
 // https://sourceforge.net/p/mingw-w64/bugs/527/
+// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=83562
 // Not setting this causes program termination on thread exit.
 #define BOOST_NO_CXX11_THREAD_LOCAL
 #endif


### PR DESCRIPTION
This was fixed in gcc 11, see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=83562