### PR TITLE
Rename mips1 to mips

### DIFF
--- a/checks/architecture/Jamfile.jam
+++ b/checks/architecture/Jamfile.jam
@@ -18,7 +18,7 @@ obj 64 : 64.cpp ;
 
 obj arm      : arm.cpp ;
 obj combined : combined.cpp ;
-obj mips1    : mips1.cpp ;
+obj mips     : mips.cpp ;
 obj power    : power.cpp ;
 obj riscv    : riscv.cpp ;
 obj sparc    : sparc.cpp ;

--- a/checks/architecture/mips.cpp
+++ b/checks/architecture/mips.cpp
@@ -7,5 +7,5 @@
 // http://www.boost.org/LICENSE_1_0.txt)
 
 #if !(defined(__mips) || defined(_MIPS_ISA_MIPS1) || defined(_R3000))
-#error "Not MIPS1"
+#error "Not MIPS"
 #endif


### PR DESCRIPTION
In fact mips1 is now used for all mips revisions.