### PR TITLE
Patch for noinline attribute on the HIP compiler.

### DIFF
--- a/include/boost/config/detail/suffix.hpp
+++ b/include/boost/config/detail/suffix.hpp
@@ -629,6 +629,9 @@ namespace std{ using ::type_info; }
        // nvcc doesn't always parse __noinline__,
        // see: https://svn.boost.org/trac/boost/ticket/9392
 #      define BOOST_NOINLINE __attribute__ ((noinline))
+#    elif defined(HIP_VERSION)
+       // See https://github.com/boostorg/config/issues/392
+#      define BOOST_NOINLINE __attribute__ ((noinline))
 #    else
 #      define BOOST_NOINLINE __attribute__ ((__noinline__))
 #    endif


### PR DESCRIPTION
Fixes https://github.com/boostorg/config/issues/392.