### PR TITLE
Update nodiscard attribute:

### DIFF
--- a/include/boost/config/detail/suffix.hpp
+++ b/include/boost/config/detail/suffix.hpp
@@ -1050,7 +1050,7 @@ namespace std{ using ::type_info; }
 #endif
 #elif defined(__has_cpp_attribute)
 // clang-6 accepts [[nodiscard]] with -std=c++14, but warns about it -pedantic
-#if __has_cpp_attribute(nodiscard) && !(defined(__clang__) && (__cplusplus < 201703L))
+#if __has_cpp_attribute(nodiscard) && !(defined(__clang__) && (__cplusplus < 201703L)) && !(defined(__GNUC__) && (__cplusplus < 201100))
 # define BOOST_ATTRIBUTE_NODISCARD [[nodiscard]]
 #endif
 #if __has_cpp_attribute(no_unique_address) && !(defined(__GNUC__) && (__cplusplus < 201100))

--- a/test/helper_macro_test.cpp
+++ b/test/helper_macro_test.cpp
@@ -41,6 +41,11 @@ typedef unsigned int BOOST_MAY_ALIAS aliasing_uint;
 
 struct BOOST_ATTRIBUTE_NODISCARD nodiscard_struct {};
 
+BOOST_ATTRIBUTE_NODISCARD int nodiscard_proc(int i)
+{
+   return i * i;
+}
+
 
 #define test_fallthrough(x) foobar(x)
 


### PR DESCRIPTION
It's not supported on functions pre-c++11 even if __has_cpp_attribute indicates it is supported.
Also update test case.
Fixes https://github.com/boostorg/config/issues/336.