### PR TITLE
Update metadata

### DIFF
--- a/meta/libraries.json
+++ b/meta/libraries.json
@@ -4,7 +4,7 @@
     "description": "Helps Boost library developers adapt to compiler idiosyncrasies; not intended for library users.",
     "documentation": "doc/html/index.html",
     "category": [
-        "workarounds"
+        "Workarounds"
     ],
     "authors": "",
     "maintainers": [


### PR DESCRIPTION
To match the pattern other boost libraries are using, the "category" values are capitalized.