### PR TITLE
Add BOOST_NULLPTR helper macro

### DIFF
--- a/doc/macro_reference.qbk
+++ b/doc/macro_reference.qbk
@@ -966,6 +966,10 @@ and must be defined for all translation units in the program, including Boost li
 This macro will no longer have any effect once an official Microsoft
 release supports the CTP features.
 ]]
+[[`BOOST_NULLPTR`][
+If `BOOST_NO_CXX11_NULLPTR` is not defined (i.e. C++11 compliant compilers), expands to `nullptr`,
+otherwise expands to `0`.
+]]
 ]
 
 [endsect]

--- a/include/boost/config/detail/suffix.hpp
+++ b/include/boost/config/detail/suffix.hpp
@@ -1069,6 +1069,12 @@ namespace std{ using ::type_info; }
 
 #define BOOST_STATIC_CONSTEXPR  static BOOST_CONSTEXPR_OR_CONST
 
+#if !defined(BOOST_NO_CXX11_NULLPTR)
+# define BOOST_NULLPTR nullptr
+#else
+# define BOOST_NULLPTR 0
+#endif
+
 //
 // Set BOOST_HAS_STATIC_ASSERT when BOOST_NO_CXX11_STATIC_ASSERT is not defined
 //

--- a/test/helper_macro_test.cpp
+++ b/test/helper_macro_test.cpp
@@ -62,6 +62,10 @@ struct trait
    enum { value = b };
 };
 
+void* test_nullptr()
+{
+   return BOOST_NULLPTR;
+}
 
 int main()
 {
@@ -82,6 +86,8 @@ int main()
       {
          result += 2;
       }
+
+      test_nullptr();
    }
    catch(int)
    {


### PR DESCRIPTION
Compilers and static analysis tools have started warning on the use of integral null pointer constants, suggesting that they need to be replaced with `nullptr`. This leads to people submitting pull requests that replace the uses of `0` with `nullptr`, such as for example https://github.com/boostorg/throw_exception/pull/22 (https://github.com/boostorg/throw_exception/pull/22/commits/8678b7cb09ad71bffbc24b099fc2a86bd925046a). However, `nullptr` is not available in C++03, which necessitates checking `BOOST_NO_CXX11_NULLPTR` as in https://github.com/boostorg/throw_exception/pull/22/commits/0a752cc9f87be1faaf8d7adcbc2cf4220623fbc1.

The proposed helper macro `BOOST_NULLPTR` expands to `nullptr` when it's supported, `0` otherwise, which avoids the need to check `BOOST_NO_CXX11_NULLPTR` in libraries themselves.

It would be more correct to expand this to `NULL` when `nullptr` isn't available, as `NULL` has special meaning for GCC and doesn't cause the warning, even in C++03 mode. But this requires that `<stddef.h>` be included in `suffix.hpp`, and I wasn't sure that this was acceptable.