### PR TITLE
Enable C++17 CTAD guides for MSVC 14.14 (VS2017 Update 7) and later

### DIFF
--- a/include/boost/config/detail/suffix.hpp
+++ b/include/boost/config/detail/suffix.hpp
@@ -1219,7 +1219,11 @@ namespace std{ using ::type_info; }
 #  define BOOST_NO_CXX20_HDR_VERSION
 #endif
 
-#if !defined(__cpp_deduction_guides) || (__cpp_deduction_guides < 201606)
+#if defined(BOOST_MSVC)
+#if (BOOST_MSVC < 1914) || (_MSVC_LANG < 201703)
+#  define BOOST_NO_CXX17_DEDUCTION_GUIDES
+#endif
+#elif !defined(__cpp_deduction_guides) || (__cpp_deduction_guides < 201606)
 #  define BOOST_NO_CXX17_DEDUCTION_GUIDES
 #endif
 


### PR DESCRIPTION
MSVC doesn't define the standard feature detection macros, so we have to resort to compiler version checks.