### PR TITLE
The std lib unary/binary_function base classes are deprecated/removed…

### DIFF
--- a/include/boost/config/stdlib/libcpp.hpp
+++ b/include/boost/config/stdlib/libcpp.hpp
@@ -168,4 +168,13 @@
 #  define BOOST_NO_CXX14_HDR_SHARED_MUTEX
 #endif
 
+#if _LIBCPP_VERSION >= 15000
+//
+// Unary function is now deprecated in C++11 and later:
+//
+#if __cplusplus >= 201103L
+#define BOOST_NO_CXX98_FUNCTION_BASE
+#endif
+#endif
+
 //  --- end ---


### PR DESCRIPTION
… from libcpp15.

Fixes https://github.com/boostorg/container_hash/issues/24.