### PR TITLE
GNU libstdc++3 _GTHREAD_USE_MUTEX_TIMEDLOCK is not used post gcc-6.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,7 +151,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        toolset: [ clang gcc ]
+        toolset: [ clang, gcc ]
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         compiler: [ g++-11, g++-12, clang++-14 ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: '0'
       - uses: mstachniuk/ci-skip@v1
@@ -65,7 +65,7 @@ jobs:
       matrix:
         compiler: [ clang++-11, clang++-12, clang++-13 ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: '0'
       - uses: mstachniuk/ci-skip@v1
@@ -109,7 +109,7 @@ jobs:
       matrix:
         compiler: [ g++-9, g++-10, clang++-9, clang++-10 ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: '0'
       - uses: mstachniuk/ci-skip@v1
@@ -153,7 +153,7 @@ jobs:
       matrix:
         toolset: [ clang, gcc-11, gcc-10, gcc-9 ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: '0'
       - uses: mstachniuk/ci-skip@v1
@@ -188,7 +188,7 @@ jobs:
       matrix:
         toolset: [ clang ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: '0'
       - uses: mstachniuk/ci-skip@v1
@@ -226,7 +226,7 @@ jobs:
       matrix:
         toolset: [ msvc-14.0 ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: '0'
       - uses: mstachniuk/ci-skip@v1
@@ -264,7 +264,7 @@ jobs:
       matrix:
         toolset: [ msvc-14.2 ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: '0'
       - uses: mstachniuk/ci-skip@v1
@@ -302,7 +302,7 @@ jobs:
       matrix:
         toolset: [ msvc-14.3 ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: '0'
       - uses: mstachniuk/ci-skip@v1
@@ -340,7 +340,7 @@ jobs:
       matrix:
         toolset: [ clang-msvc-14.3 ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: '0'
       - uses: mstachniuk/ci-skip@v1
@@ -375,8 +375,8 @@ jobs:
       matrix:
         qemu_arch: [ aarch64, s390x, ppc64le ]
     steps:
-      - uses: actions/checkout@v2.1.0
-      - uses: uraimo/run-on-arch-action@v2.0.5
+      - uses: actions/checkout@v3
+      - uses: uraimo/run-on-arch-action@v2
         name: Run commands
         id: runcmd
         with:
@@ -411,8 +411,8 @@ jobs:
       matrix:
         qemu_arch: [ aarch64, ppc64le ]
     steps:
-      - uses: actions/checkout@v2.1.0
-      - uses: uraimo/run-on-arch-action@v2.0.5
+      - uses: actions/checkout@v3
+      - uses: uraimo/run-on-arch-action@v2
         name: Run commands
         id: runcmd
         with:
@@ -448,7 +448,7 @@ jobs:
       matrix:
         compiler: [ emcc ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: '0'
       - uses: mstachniuk/ci-skip@v1
@@ -525,7 +525,7 @@ jobs:
       matrix:
         std: [ 11, 14, 17 ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: '0'
       - uses: mstachniuk/ci-skip@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,7 +186,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        toolset: [ clang, gcc-11 ]
+        toolset: [ clang ]
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,8 +146,43 @@ jobs:
       - name: Test
         run: ../../../b2 toolset=$TOOLSET cxxstd=03,11,14,17,2a
         working-directory: ../boost-root/libs/config/test
-  macos:
-    runs-on: macos-latest
+  macos_11:
+    runs-on: macos-11
+    strategy:
+      fail-fast: false
+      matrix:
+        toolset: [ clang, gcc-11, gcc-10, gcc-9 ]
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: '0'
+      - uses: mstachniuk/ci-skip@v1
+        with:
+          commit-filter: '[skip ci];[ci skip];[CI SKIP];[SKIP CI];***CI SKIP***;***SKIP CI***;[windows];[Windows];[WINDOWS];[linux];[Linux];[LINUX]'
+          commit-filter-separator: ';'
+          fail-fast: true
+      - name: Checkout main boost
+        run: git clone -b develop --depth 1 https://github.com/boostorg/boost.git ../boost-root
+      - name: Update Dependencies
+        run: git submodule update --init tools/build tools/boost_install libs/headers libs/detail libs/core libs/assert libs/type_traits
+        working-directory: ../boost-root
+      - name: Copy files
+        run: cp -r $GITHUB_WORKSPACE/* libs/config
+        working-directory: ../boost-root
+      - name: Bootstrap
+        run: ./bootstrap.sh
+        working-directory: ../boost-root
+      - name: Generate headers
+        run: ./b2 headers
+        working-directory: ../boost-root
+      - name: Config info
+        run: ../../../b2 print_config_info toolset=${{ matrix.toolset }} cxxstd=03,11,14,17,2a
+        working-directory: ../boost-root/libs/config/test
+      - name: Test
+        run: ../../../b2 toolset=${{ matrix.toolset }} cxxstd=03,11,14,17,2a
+        working-directory: ../boost-root/libs/config/test
+  macos_12:
+    runs-on: macos-12
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,7 +151,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        toolset: [ clang, gcc ]
+        toolset: [ clang, gcc-11 ]
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,7 +151,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        toolset: [ clang ]
+        toolset: [ clang gcc ]
     steps:
       - uses: actions/checkout@v2
         with:

--- a/include/boost/config/stdlib/libstdcpp3.hpp
+++ b/include/boost/config/stdlib/libstdcpp3.hpp
@@ -459,7 +459,7 @@ extern "C" char *gets (char *__s);
 #  endif
 #endif
 
-#if (!defined(_GTHREAD_USE_MUTEX_TIMEDLOCK) || (_GTHREAD_USE_MUTEX_TIMEDLOCK == 0)) && !defined(BOOST_NO_CXX11_HDR_MUTEX)
+#if (!defined(_GTHREAD_USE_MUTEX_TIMEDLOCK) || (_GTHREAD_USE_MUTEX_TIMEDLOCK == 0)) && !defined(BOOST_NO_CXX11_HDR_MUTEX) && (__GNUC__ < 6)
 // Timed mutexes are not always available:
 #  define BOOST_NO_CXX11_HDR_MUTEX
 #endif


### PR DESCRIPTION
Fixes: https://github.com/boostorg/config/issues/399.