### PR TITLE
Fix -Wundef for `_GLIBCXX_USE_DEPRECATED` on libstdc++ >= 4.6

### DIFF
--- a/include/boost/config/stdlib/libstdcpp3.hpp
+++ b/include/boost/config/stdlib/libstdcpp3.hpp
@@ -259,7 +259,7 @@ extern "C" char *gets (char *__s);
 #     if !_GLIBCXX_DEPRECATED
 #        define BOOST_NO_AUTO_PTR
 #     endif
-#  elif !_GLIBCXX_USE_DEPRECATED
+#  elif !defined(_GLIBCXX_USE_DEPRECATED) || !_GLIBCXX_USE_DEPRECATED
 #     define BOOST_NO_AUTO_PTR
 #     define BOOST_NO_CXX98_BINDERS
 #  endif


### PR DESCRIPTION
See https://github.com/boostorg/type_traits/pull/176#issuecomment-1304871472