### PR TITLE
Declare BOOST_ATTRIBUTE_UNUSED to be [[maybe_unused]] in C++17

### DIFF
--- a/include/boost/config/detail/suffix.hpp
+++ b/include/boost/config/detail/suffix.hpp
@@ -1039,7 +1039,11 @@ namespace std{ using ::type_info; }
 // Unused variable/typedef workarounds:
 //
 #ifndef BOOST_ATTRIBUTE_UNUSED
-#  define BOOST_ATTRIBUTE_UNUSED
+#  if __cplusplus < 201703L
+#    define BOOST_ATTRIBUTE_UNUSED
+#  else
+#    define BOOST_ATTRIBUTE_UNUSED [[maybe_unused]]
+#  endif
 #endif
 //
 // [[nodiscard]]:


### PR DESCRIPTION
See https://github.com/boostorg/serialization/issues/271 and https://github.com/boostorg/serialization/issues/145

I'm getting a compiler warning (or rather error since I try to compile with "treat warnings as errors") in Visual Studio 2022.

Since this became a standard in C++17 (https://en.cppreference.com/w/cpp/language/attributes/maybe_unused), it might be worth using that one. The compiler warning disappears.