### PR TITLE
Fix some C++23 testing issues:

### DIFF
--- a/test/boost_no_cxx11_hdr_type_traits.ipp
+++ b/test/boost_no_cxx11_hdr_type_traits.ipp
@@ -99,8 +99,11 @@ int test()
   using std::remove_all_extents;
   using std::remove_pointer;
   using std::add_pointer;
+#if !((__cplusplus > 202002L) || (defined(_MSVC_LANG) && (_MSVC_LANG > 202002L)))
+  // deprecated in C++23:
   using std::aligned_storage;
   using std::aligned_union;
+#endif
   using std::decay;
   using std::enable_if;
   using std::conditional;

--- a/test/boost_no_unified_init.ipp
+++ b/test/boost_no_unified_init.ipp
@@ -34,7 +34,7 @@ struct IdString
 {
    std::string name;
    int identifier;
-   bool operator == (const IdString& other)
+   bool operator == (const IdString& other)const
    {
       return identifier == other.identifier && name == other.name;
    }


### PR DESCRIPTION
Deprecated type_traits and non-const operator==.
Fixes https://github.com/boostorg/config/issues/460