### PR TITLE
Update cxxstd values for GHA msvc jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,10 +249,10 @@ jobs:
         run: b2 headers
         working-directory: ../boost-root
       - name: Config info
-        run: ..\..\..\b2 print_config_info cxxstd=14,17 address-model=64 toolset=msvc-14.0
+        run: ..\..\..\b2 print_config_info cxxstd=14,latest address-model=64 toolset=msvc-14.0
         working-directory: ../boost-root/libs/config/test
       - name: Test
-        run: ..\..\..\b2 --hash address-model=64 cxxstd=14,17 toolset=msvc-14.0
+        run: ..\..\..\b2 --hash address-model=64 cxxstd=14,latest toolset=msvc-14.0
         working-directory: ../boost-root/libs/config/test
   windows_msvc_14_2:
     runs-on: windows-2019
@@ -287,10 +287,10 @@ jobs:
         run: b2 headers
         working-directory: ../boost-root
       - name: Config info
-        run: ..\..\..\b2 print_config_info cxxstd=14,17,latest address-model=64 toolset=msvc-14.2
+        run: ..\..\..\b2 print_config_info cxxstd=14,17,20,latest address-model=64 toolset=msvc-14.2
         working-directory: ../boost-root/libs/config/test
       - name: Test
-        run: ..\..\..\b2 --hash address-model=64 cxxstd=14,17,latest toolset=msvc-14.2
+        run: ..\..\..\b2 --hash address-model=64 cxxstd=14,17,20,latest toolset=msvc-14.2
         working-directory: ../boost-root/libs/config/test
   windows_msvc_14_3:
     runs-on: windows-2022
@@ -325,10 +325,10 @@ jobs:
         run: b2 headers
         working-directory: ../boost-root
       - name: Config info
-        run: ..\..\..\b2 print_config_info cxxstd=14,17,latest address-model=64 toolset=msvc-14.3
+        run: ..\..\..\b2 print_config_info cxxstd=14,17,20,latest address-model=64 toolset=msvc-14.3
         working-directory: ../boost-root/libs/config/test
       - name: Test
-        run: ..\..\..\b2 --hash address-model=64 cxxstd=14,17,latest toolset=msvc-14.3
+        run: ..\..\..\b2 --hash address-model=64 cxxstd=14,17,20,latest toolset=msvc-14.3
         working-directory: ../boost-root/libs/config/test
   windows_clang_msvc_14_3:
     runs-on: windows-2022


### PR DESCRIPTION
msvc-14.0 doesn't have `/std:c++17`, only `/std:c++latest`, so the `cxxstd=17` job did nothing.

While here I also added 20 to msvc-14.2 and msvc-14.3, because they support that now.