### PR TITLE
Use `__apple_build_version__` to detect Apple clang

### DIFF
--- a/include/boost/config/compiler/clang_version.hpp
+++ b/include/boost/config/compiler/clang_version.hpp
@@ -2,7 +2,7 @@
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt)
 
-#if !defined(__APPLE__)
+#if !defined(__apple_build_version__)
 
 # define BOOST_CLANG_VERSION (__clang_major__ * 10000 + __clang_minor__ * 100 + __clang_patchlevel__ % 100)
 


### PR DESCRIPTION
…since `__APPLE__` is defined by both Apple Clang and LLVM.org Clang on Apple platforms (as mentioned by https://github.com/boostorg/config/pull/39#issuecomment-59946538).

This ensures `BOOST_CLANG_VERSION` is defined correctly when using LLVM.org clang.
| Compiler               | Before | After  |
|------------------------|--------|--------|
| Xcode 14.2 Apple Clang | `140000` | `140000` |
| LLVM.org Clang 17.0.3  | `140000` | `170003` |
| LLVM.org Clang 9.0.1   | `40000`  | `90001`  |