### PR TITLE
Update BOOST_COMPILER_VERSION for msvc 19.4x (VS 2022 17.10)

### DIFF
--- a/include/boost/config/compiler/visualc.hpp
+++ b/include/boost/config/compiler/visualc.hpp
@@ -372,7 +372,7 @@
 #     define BOOST_COMPILER_VERSION 14.1
 #   elif _MSC_VER < 1930
 #     define BOOST_COMPILER_VERSION 14.2
-#   elif _MSC_VER < 1940
+#   elif _MSC_VER < 1950
 #     define BOOST_COMPILER_VERSION 14.3
 #   else
 #     define BOOST_COMPILER_VERSION _MSC_VER
@@ -385,8 +385,8 @@
 #include <boost/config/pragma_message.hpp>
 
 //
-// last known and checked version is 19.3x (VS2022):
-#if (_MSC_VER >= 1940)
+// last known and checked version is 19.4x (VS2022):
+#if (_MSC_VER >= 1950)
 #  if defined(BOOST_ASSERT_CONFIG)
 #     error "Boost.Config is older than your current compiler version."
 #  elif !defined(BOOST_CONFIG_SUPPRESS_OUTDATED_MESSAGE)


### PR DESCRIPTION
Fixes boostorg/config#496

According to the anouncement https://devblogs.microsoft.com/cppblog/msvc-toolset-minor-version-number-14-40-in-vs-2022-v17-10/ and the 17.10 VS release 
toolset name "v143" is retained
toolset version is extended by another decade
and we can assume the _MSC_VER follows this pattern