### PR TITLE
Add support for modular build structure.

### DIFF
--- a/build.jam
+++ b/build.jam
@@ -3,6 +3,8 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
+require-b2 5.1 ;
+
 require-b2 5 ;
 
 import project ;

--- a/build.jam
+++ b/build.jam
@@ -1,0 +1,34 @@
+# Copyright René Ferdinand Rivera Morell 2023
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+require-b2 5 ;
+
+import project ;
+import modules ;
+
+path-constant BOOST_CONFIG_ROOT : . ;
+import-search $(BOOST_CONFIG_ROOT)/checks ;
+
+project /boost/config
+    : common-requirements
+        <include>include
+    ;
+
+explicit
+    [ alias boost_config ]
+    [ alias all : boost_config test ]
+    [ alias testing
+        : # sources
+        : # requirements
+        : # default-buidl
+        : # usage-requirements
+            <include>test
+        ]
+    ;
+
+call-if : boost-library config
+    ;
+
+use-project /boost/architecture : checks/architecture ;

--- a/build.jam
+++ b/build.jam
@@ -3,12 +3,7 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-require-b2 5.1 ;
-
-require-b2 5 ;
-
-import project ;
-import modules ;
+require-b2 5.2 ;
 
 path-constant BOOST_CONFIG_ROOT : . ;
 import-search $(BOOST_CONFIG_ROOT)/checks ;

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -10,15 +10,19 @@
 
 import feature ;
 import testing ;
+import notfile ;
 
 project
     : requirements
       <toolset>gcc:<cxxflags>-Wno-deprecated-declarations
+      <source>/boost/core//boost_core
+      <source>/boost/detail//boost_detail
+      <source>/boost/type_traits//boost_type_traits
 ;
 
 
 import modules ;
-import ../checks/config : requires ;
+import config : requires ;
 
 local is_unix = [ modules.peek : UNIX ] ;
 

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -22,6 +22,7 @@ project
 
 
 import modules ;
+import-search /boost/config/checks ;
 import config : requires ;
 
 local is_unix = [ modules.peek : UNIX ] ;
@@ -102,7 +103,7 @@ test-suite config
           <threading>single
           <define>BOOST_DYN_LINK=1
           <define>BOOST_CONFIG_NO_LIB=1
-          <target-os>vxworks:<link>shared  
+          <target-os>vxworks:<link>shared
           :
           config_link_test
     ]

--- a/tools/Jamfile.v2
+++ b/tools/Jamfile.v2
@@ -1,11 +1,11 @@
 # Copyright John Maddock 2005.
-# Use, modification and distribution are subject to the 
-# Boost Software License, Version 1.0. (See accompanying file 
+# Use, modification and distribution are subject to the
+# Boost Software License, Version 1.0. (See accompanying file
 # LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-run generate.cpp 
-   ../../regex/build//boost_regex 
-   ../../filesystem/build//boost_filesystem ../../system/build//boost_system 
+run generate.cpp
+   /boost/regex//boost_regex
+   /boost/filesystem//boost_filesystem /boost/system//boost_system
    : ../../..
 ;
 


### PR DESCRIPTION
This is part of the effort to make the Boost libraries "modular" for build and consumption. See https://lists.boost.org/Archives/boost/2024/01/255704.php and https://github.com/grafikrobot/boost-b2-modular/blob/b2-modular/README.adoc for more information.

This PR depends on the following other PRs being merged to both develop and master branches of the respective repos:

- https://github.com/boostorg/boost/pull/854
- https://github.com/boostorg/auto_index/pull/7
- https://github.com/boostorg/bcp/pull/20
- https://github.com/boostorg/boost_install/pull/69
- https://github.com/boostorg/boost/pull/890
- https://github.com/boostorg/boostbook/pull/25
- https://github.com/boostorg/boostdep/pull/21
- https://github.com/boostorg/docca/pull/143
- https://github.com/boostorg/inspect/pull/19
- https://github.com/boostorg/quickbook/pull/25

This PR will be changed to ready for review, i.e. not draft, when the above are merged. Do not merge this one until that time.