### PR TITLE
Typo fix: "unavaliable"

### DIFF
--- a/include/boost/config/requires_threads.hpp
+++ b/include/boost/config/requires_threads.hpp
@@ -26,7 +26,7 @@
 
 #endif
 
-#  error "Threading support unavaliable: it has been explicitly disabled with BOOST_DISABLE_THREADS"
+#  error "Threading support unavailable: it has been explicitly disabled with BOOST_DISABLE_THREADS"
 
 #elif !defined(BOOST_HAS_THREADS)
 


### PR DESCRIPTION
Small typo fix in compilation error message.