### PR TITLE
Fix BOOST_HAS_NL_TYPES_H on cygwin

### DIFF
--- a/include/boost/config/platform/cygwin.hpp
+++ b/include/boost/config/platform/cygwin.hpp
@@ -59,13 +59,9 @@
 // boilerplate code:
 #include <boost/config/detail/posix_features.hpp>
 
-//
-// Cygwin lies about XSI conformance, there is no nl_types.h:
-//
+#if (CYGWIN_VERSION_API_MAJOR == 0 && CYGWIN_VERSION_API_MINOR < 325)
+// Prior to CYGWIN_VERSION_API_MINOR=325 Cygwin lies about XSI conformance, there is no nl_types.h:
 #ifdef BOOST_HAS_NL_TYPES_H
 #  undef BOOST_HAS_NL_TYPES_H
 #endif
-
-
-
-
+#endif


### PR DESCRIPTION
Starting from CYGWIN_VERSION_API_MINOR=325 `catclose`, `catgets`, `catopen` are exported (see `<cygwin/version.h>` [line 455](https://github.com/msys2/msys2-runtime/blob/3819160299787e0ca64098a3e8945853291b135d/winsup/cygwin/include/cygwin/version.h#L455))