### PR TITLE
Add BOOST_LIBSTDCXX_VERSION_WORKAROUND_GUARD

### DIFF
--- a/include/boost/config/workaround.hpp
+++ b/include/boost/config/workaround.hpp
@@ -264,6 +264,11 @@
 #else
 #define BOOST_CLANG_VERSION_WORKAROUND_GUARD 0
 #endif
+#ifndef BOOST_LIBSTDCXX_VERSION
+#define BOOST_LIBSTDCXX_VERSION_WORKAROUND_GUARD 1
+#else
+#define BOOST_LIBSTDCXX_VERSION_WORKAROUND_GUARD 0
+#endif
 
 // Always define to zero, if it's used it'll be defined my MPL:
 #define BOOST_MPL_CFG_GCC_WORKAROUND_GUARD 0


### PR DESCRIPTION
This avoids the `-Wundef` warning when `BOOST_WORKAROUND(BOOST_LIBSTDCXX_VERSION, ...)` is used without a `defined(BOOST_LIBSTDCXX_VERSION)` check.