### PR TITLE
Fix Clang Boost wchar_t redefinition

### DIFF
--- a/include/boost/config/compiler/clang.hpp
+++ b/include/boost/config/compiler/clang.hpp
@@ -366,5 +366,15 @@
 // Macro used to identify the Clang compiler.
 #define BOOST_CLANG 1
 
+//
+// When targeting MSVC compatibility (clang-cl), wchar_t is only a distinct intrinsic
+// type when _NATIVE_WCHAR_T_DEFINED is defined (i.e. /Zc:wchar_t).  Under /Zc:wchar_t-,
+// wchar_t is an alias for unsigned short, so mirror visualc.hpp here to avoid emitting a
+// duplicate wchar_t specialization that redefines the unsigned short one.
+//
+#if defined(_MSC_VER) && !defined(_NATIVE_WCHAR_T_DEFINED)
+#  define BOOST_NO_INTRINSIC_WCHAR_T
+#endif
+
 // BOOST_CLANG_VERSION
 #include <boost/config/compiler/clang_version.hpp>


### PR DESCRIPTION
## Why:
When clang targets MSVC compatibility (clang-cl, so _MSC_VER is defined) and is built with /Zc:wchar_t- , wchar_t is an alias for unsigned short rather than a distinct intrinsic type, and _NATIVE_WCHAR_T_DEFINED is not defined.

In that configuration Boost emits a [separate is_integral<wchar_t> specialization](https://github.com/boostorg/type_traits/blob/cc6fc3daa8e20c4a70b563d67ceb4c34d8c1c4d7/include/boost/type_traits/is_integral.hpp#L47) that collides with the unsigned short one, producing errors such as: `redefinition of 'is_integral<unsigned short>'`

## What:
visualc.hpp already guards against this by defining BOOST_NO_INTRINSIC_WCHAR_T when _NATIVE_WCHAR_T_DEFINED is absent; clang.hpp was missing the equivalent guard. Mirror the visualc.hpp behaviour here. 

## Validation:
Local build on consumer side with MSVC and Clang-cl passed