### PR TITLE
Enable [[msvc::no_unique_address]] attribute.

### DIFF
--- a/include/boost/config/compiler/visualc.hpp
+++ b/include/boost/config/compiler/visualc.hpp
@@ -273,6 +273,11 @@
 #define BOOST_NO_CXX17_AUTO_NONTYPE_TEMPLATE_PARAMS
 #endif
 
+#if _MSC_FULL_VER >= 192829913
+// Works with /std:c++14 and /std:c++17, and performs optimization
+#define BOOST_ATTRIBUTE_NO_UNIQUE_ADDRESS [[msvc::no_unique_address]]
+#endif
+
 //
 // Things that don't work in clr mode:
 //

--- a/include/boost/config/detail/suffix.hpp
+++ b/include/boost/config/detail/suffix.hpp
@@ -1097,7 +1097,7 @@ namespace std{ using ::type_info; }
 #if __has_attribute(nodiscard)
 # define BOOST_ATTRIBUTE_NODISCARD [[nodiscard]]
 #endif
-#if __has_attribute(no_unique_address)
+#if __has_attribute(no_unique_address)  && !defined(BOOST_ATTRIBUTE_NO_UNIQUE_ADDRESS)
 # define BOOST_ATTRIBUTE_NO_UNIQUE_ADDRESS [[no_unique_address]]
 #endif
 #elif defined(__has_cpp_attribute)
@@ -1105,7 +1105,7 @@ namespace std{ using ::type_info; }
 #if __has_cpp_attribute(nodiscard) && !(defined(__clang__) && (__cplusplus < 201703L)) && !(defined(__GNUC__) && (__cplusplus < 201100))
 # define BOOST_ATTRIBUTE_NODISCARD [[nodiscard]]
 #endif
-#if __has_cpp_attribute(no_unique_address) && !(defined(__GNUC__) && (__cplusplus < 201100))
+#if __has_cpp_attribute(no_unique_address) && !(defined(__GNUC__) && (__cplusplus < 201100)) && !defined(BOOST_ATTRIBUTE_NO_UNIQUE_ADDRESS)
 # define BOOST_ATTRIBUTE_NO_UNIQUE_ADDRESS [[no_unique_address]]
 #endif
 #endif


### PR DESCRIPTION
See https://devblogs.microsoft.com/cppblog/msvc-cpp20-and-the-std-cpp20-switch/#c20-no_unique_address Fixes: https://github.com/boostorg/config/issues/499