### PR TITLE
Add an Alpha architecture check

### DIFF
--- a/checks/architecture/Jamfile.jam
+++ b/checks/architecture/Jamfile.jam
@@ -16,6 +16,7 @@ project /boost/architecture
 obj 32 : 32.cpp ;
 obj 64 : 64.cpp ;
 
+obj alpha    : alpha.cpp ;
 obj arm      : arm.cpp ;
 obj combined : combined.cpp ;
 obj loongarch : loongarch.cpp ;

--- a/checks/architecture/alpha.cpp
+++ b/checks/architecture/alpha.cpp
@@ -1,0 +1,9 @@
+// alpha.cpp
+//
+// Distributed under the Boost Software License Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(__alpha__) && !defined(__alpha) && !defined(_M_ALPHA)
+#error "Not Alpha"
+#endif


### PR DESCRIPTION
The checks under checks/architecture are what the superproject's architecture deduction compiles to identify the host, and there was no Alpha check for it to find.

The macros match the ones boost/predef/architecture/alpha.h already keys on.